### PR TITLE
DRUPAL-49: Drupal 9 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "drupal/config_split": ">=1.4",
         "drupal/components": ">=1.1",
         "drupal/config_direct_save": ">=1.0",
-        "drupal/config_installer": ">=1.0",
         "drupal/contact_storage": "1.x-dev",
         "drupal/devel": ">=2.1",
         "drupal/diff": ">=1.0",

--- a/whiplash.info.yml
+++ b/whiplash.info.yml
@@ -1,7 +1,7 @@
 name: Whiplash
 type: profile
 description: 'Forum One starting profile for new Drupal 8 builds.'
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 install:
   - admin_toolbar
   - admin_toolbar_links_access_filter


### PR DESCRIPTION
This likely needs to go into a 9.x version of this install profile.

* Removing config_installer module as there is no D9 version. 
* Adding core_version_requirement for D9 compatibility.