### PR TITLE
[DRUPAL-36] Making administrator role the 'admin' of the site 

### DIFF
--- a/config/install/user.role.administrator.yml
+++ b/config/install/user.role.administrator.yml
@@ -7,7 +7,7 @@ _core:
 id: administrator
 label: Administrator
 weight: 2
-is_admin: null
+is_admin: true
 permissions:
   - 'access administration pages'
   - 'access content overview'


### PR DESCRIPTION
`is_admin` is what is used to determine the 'Administrator Role' of the site (ensures new permissions are added to this user role).

Note: I checked the other roles in the profile to confirm that their `is_admin` property were set to `false`.