### PR TITLE
[DRUPAL-20] Removing all uuid and _core/default_config_hash 

### DIFF
--- a/config/install/automated_cron.settings.yml
+++ b/config/install/automated_cron.settings.yml
@@ -1,3 +1,1 @@
 interval: 10800
-_core:
-  default_config_hash: 9Qvv81IbSzw1X8bXDF61cxZq0CctJmFd_53CRazUKJk

--- a/config/install/block.block.gesso_admin.yml
+++ b/config/install/block.block.gesso_admin.yml
@@ -1,4 +1,3 @@
-uuid: 1ab249f4-52b8-498f-b31a-278c32bcd9aa
 langcode: en
 status: true
 dependencies:
@@ -8,8 +7,6 @@ dependencies:
     - system
   theme:
     - gesso
-_core:
-  default_config_hash: Im1XUpwe66-9uRGBZtt6hBdnXTmiv9na9Urasop2O0I
 id: gesso_admin
 theme: gesso
 region: header

--- a/config/install/block.block.gesso_branding.yml
+++ b/config/install/block.block.gesso_branding.yml
@@ -1,4 +1,3 @@
-uuid: 41613b13-71b6-4bfb-99ce-5b8d280bec03
 langcode: en
 status: true
 dependencies:
@@ -6,8 +5,6 @@ dependencies:
     - system
   theme:
     - gesso
-_core:
-  default_config_hash: ZvvtWFGKGCjTC0s40tMe-aSpx1y-YKGC72T92q97YoM
 id: gesso_branding
 theme: gesso
 region: header

--- a/config/install/block.block.gesso_local_actions.yml
+++ b/config/install/block.block.gesso_local_actions.yml
@@ -1,11 +1,8 @@
-uuid: 169a1d3f-3675-4070-b9b2-c77d323ac030
 langcode: en
 status: true
 dependencies:
   theme:
     - gesso
-_core:
-  default_config_hash: fRuyDTtLpalXZEA50qBdfCh6lCLkLCFAVTFrEgxveW8
 id: gesso_local_actions
 theme: gesso
 region: content

--- a/config/install/block.block.gesso_local_tasks.yml
+++ b/config/install/block.block.gesso_local_tasks.yml
@@ -1,11 +1,8 @@
-uuid: 3bc553a8-ebeb-49a9-a6d3-5c8f7c3201bb
 langcode: en
 status: true
 dependencies:
   theme:
     - gesso
-_core:
-  default_config_hash: rgGMgKW2yA2rVKTmV6qcvaX5TNjmwUN27wYV2f7LQJ4
 id: gesso_local_tasks
 theme: gesso
 region: content

--- a/config/install/block.block.gesso_messages.yml
+++ b/config/install/block.block.gesso_messages.yml
@@ -1,4 +1,3 @@
-uuid: fd205114-4980-46cc-a0fe-d83191352029
 langcode: en
 status: true
 dependencies:
@@ -6,8 +5,6 @@ dependencies:
     - system
   theme:
     - gesso
-_core:
-  default_config_hash: uk6kI_Y8CqRDwqABfeppBNVa3hXoO2sKIG53FnkWSmg
 id: gesso_messages
 theme: gesso
 region: highlighted

--- a/config/install/block.block.gesso_page_title.yml
+++ b/config/install/block.block.gesso_page_title.yml
@@ -1,11 +1,8 @@
-uuid: ed6dbfc9-cb2f-4529-a4dd-82b8340383d1
 langcode: en
 status: true
 dependencies:
   theme:
     - gesso
-_core:
-  default_config_hash: w4Fhigr27pLM2uAWT7BX7VKIhvYyI6SVvc_tF3p1mkI
 id: gesso_page_title
 theme: gesso
 region: content

--- a/config/install/block.block.gesso_tools.yml
+++ b/config/install/block.block.gesso_tools.yml
@@ -1,4 +1,3 @@
-uuid: 7e20e4ca-d1b4-49bc-9879-5f939bf72621
 langcode: en
 status: true
 dependencies:
@@ -8,8 +7,6 @@ dependencies:
     - system
   theme:
     - gesso
-_core:
-  default_config_hash: J-Iuy6r6ujrajlDGzBsVvP9rvYAAf4ZVbKRmpAr4RiA
 id: gesso_tools
 theme: gesso
 region: header

--- a/config/install/block.block.seven_admin.yml
+++ b/config/install/block.block.seven_admin.yml
@@ -1,4 +1,3 @@
-uuid: f59f357c-0e4b-497f-8e00-bce203cf3e9b
 langcode: en
 status: false
 dependencies:
@@ -8,8 +7,6 @@ dependencies:
     - system
   theme:
     - seven
-_core:
-  default_config_hash: zjfQFEd3ztU6-5SwetpjTYArig4ff230Omvv9HkzvDo
 id: seven_admin
 theme: seven
 region: header

--- a/config/install/block.block.seven_branding.yml
+++ b/config/install/block.block.seven_branding.yml
@@ -1,4 +1,3 @@
-uuid: 7a179409-5d8c-458e-a3b7-ae05951998c1
 langcode: en
 status: false
 dependencies:
@@ -6,8 +5,6 @@ dependencies:
     - system
   theme:
     - seven
-_core:
-  default_config_hash: nyRF65_-zSE-4nl2P26wPpB-fSQ3gqCHiw5zh8UQUFM
 id: seven_branding
 theme: seven
 region: header

--- a/config/install/block.block.seven_local_actions.yml
+++ b/config/install/block.block.seven_local_actions.yml
@@ -1,11 +1,8 @@
-uuid: eb20992d-c19f-4452-adaa-aa33581ad328
 langcode: en
 status: true
 dependencies:
   theme:
     - seven
-_core:
-  default_config_hash: tgKMpcIhFW1E8KNmfYvQ2k83LQ0PS9a4NtqedFXPvE0
 id: seven_local_actions
 theme: seven
 region: content

--- a/config/install/block.block.seven_local_tasks.yml
+++ b/config/install/block.block.seven_local_tasks.yml
@@ -1,11 +1,8 @@
-uuid: 6f004421-c5a4-42e2-9ad8-111a53f0eebb
 langcode: en
 status: true
 dependencies:
   theme:
     - seven
-_core:
-  default_config_hash: HRMOS27g-KzTtnfeURKwOSt219_A0YW6B6sjxKUebnU
 id: seven_local_tasks
 theme: seven
 region: content

--- a/config/install/block.block.seven_messages.yml
+++ b/config/install/block.block.seven_messages.yml
@@ -1,4 +1,3 @@
-uuid: e3359c0b-edcd-465e-ad54-c39301b69b9d
 langcode: en
 status: true
 dependencies:
@@ -6,8 +5,6 @@ dependencies:
     - system
   theme:
     - seven
-_core:
-  default_config_hash: EcPjBFQ4xohrFXIO3yz5sPvvtpVSmgRPCs73j1BzZ2Q
 id: seven_messages
 theme: seven
 region: highlighted

--- a/config/install/block.block.seven_page_title.yml
+++ b/config/install/block.block.seven_page_title.yml
@@ -1,11 +1,8 @@
-uuid: 2bd517d7-b5f1-447a-b79a-1e56b0b262e8
 langcode: en
 status: true
 dependencies:
   theme:
     - seven
-_core:
-  default_config_hash: 07KJ_OkE-Ktnbdtov4X8iudvQG6jo_ROddyQ6hHxHLI
 id: seven_page_title
 theme: seven
 region: content

--- a/config/install/block.block.seven_tools.yml
+++ b/config/install/block.block.seven_tools.yml
@@ -1,4 +1,3 @@
-uuid: d83c6018-27a6-41ab-b8be-f62903f029f9
 langcode: en
 status: false
 dependencies:
@@ -8,8 +7,6 @@ dependencies:
     - system
   theme:
     - seven
-_core:
-  default_config_hash: '-bzFrw4w1mfCvnnU8U5pbfJyA1HXaR-1MAqhFpOMmWs'
 id: seven_tools
 theme: seven
 region: header

--- a/config/install/block.block.stark_admin.yml
+++ b/config/install/block.block.stark_admin.yml
@@ -1,4 +1,3 @@
-uuid: 1409ef10-2842-48ed-a7e9-1dd962a1747c
 langcode: en
 status: true
 dependencies:
@@ -8,8 +7,6 @@ dependencies:
     - system
   theme:
     - stark
-_core:
-  default_config_hash: OAolHaY02f74nOchyYgjhswBPCMyplY8vMR_TR3au-Q
 id: stark_admin
 theme: stark
 region: sidebar_first

--- a/config/install/block.block.stark_branding.yml
+++ b/config/install/block.block.stark_branding.yml
@@ -1,4 +1,3 @@
-uuid: e4d7ef9b-6840-4833-9cfd-4a097b312bab
 langcode: en
 status: true
 dependencies:
@@ -6,8 +5,6 @@ dependencies:
     - system
   theme:
     - stark
-_core:
-  default_config_hash: eHDmz76ZDi_Jpf4SZSp3WsSTj7iO8yGl7ltT2hUuI3k
 id: stark_branding
 theme: stark
 region: header

--- a/config/install/block.block.stark_local_actions.yml
+++ b/config/install/block.block.stark_local_actions.yml
@@ -1,11 +1,8 @@
-uuid: 1ff411ad-6da7-4a29-9469-a64c2357d920
 langcode: en
 status: true
 dependencies:
   theme:
     - stark
-_core:
-  default_config_hash: 7XZvkq3FLjY1azFxf5mLWN3xXoA3giObrkgLPa8YKWU
 id: stark_local_actions
 theme: stark
 region: content

--- a/config/install/block.block.stark_local_tasks.yml
+++ b/config/install/block.block.stark_local_tasks.yml
@@ -1,11 +1,8 @@
-uuid: 3e655865-a07c-4758-911f-19b857732f8b
 langcode: en
 status: true
 dependencies:
   theme:
     - stark
-_core:
-  default_config_hash: '-6jh_3avXGK-E_xNX2Pgsxrb2WDb4qorEfGujVZfoTE'
 id: stark_local_tasks
 theme: stark
 region: content

--- a/config/install/block.block.stark_messages.yml
+++ b/config/install/block.block.stark_messages.yml
@@ -1,4 +1,3 @@
-uuid: 155f869f-9be7-48eb-8fa1-a67669a6ea46
 langcode: en
 status: true
 dependencies:
@@ -6,8 +5,6 @@ dependencies:
     - system
   theme:
     - stark
-_core:
-  default_config_hash: UtLfGFMz8XdqP0bUPhTtr3Ud0JxERuFiasJHUiiK_P8
 id: stark_messages
 theme: stark
 region: highlighted

--- a/config/install/block.block.stark_page_title.yml
+++ b/config/install/block.block.stark_page_title.yml
@@ -1,11 +1,8 @@
-uuid: 6c15391f-7337-4d36-86bd-2d50a31d8506
 langcode: en
 status: true
 dependencies:
   theme:
     - stark
-_core:
-  default_config_hash: dlJ4QOiQtbkwgqPkVXfClvjdSxwoUi0IrghqylGPHC8
 id: stark_page_title
 theme: stark
 region: content

--- a/config/install/block.block.stark_tools.yml
+++ b/config/install/block.block.stark_tools.yml
@@ -1,4 +1,3 @@
-uuid: 086927c9-0e3d-4939-94c5-8872dbc24f6d
 langcode: en
 status: true
 dependencies:
@@ -8,8 +7,6 @@ dependencies:
     - system
   theme:
     - stark
-_core:
-  default_config_hash: NrKk7RD-PMeAomrP0KgByO1biyIOH0hNhMhmuaSCRRo
 id: stark_tools
 theme: stark
 region: sidebar_first

--- a/config/install/components.settings.yml
+++ b/config/install/components.settings.yml
@@ -1,3 +1,1 @@
 namespace_prefix: 0
-_core:
-  default_config_hash: ubgzimJBOnDVwucabHMNyh86hpBDgl1ytWQyexq4L6I

--- a/config/install/core.base_field_override.node.page.promote.yml
+++ b/config/install/core.base_field_override.node.page.promote.yml
@@ -1,11 +1,8 @@
-uuid: f91ff2ab-f85d-4932-b91b-9d2ddf8692cf
 langcode: en
 status: true
 dependencies:
   config:
     - node.type.page
-_core:
-  default_config_hash: 1PJNFfYPs-F6LiPAhWU4kquB5-7z67_9mrXRa2KUsX8
 id: node.page.promote
 field_name: promote
 entity_type: node

--- a/config/install/core.date_format.fallback.yml
+++ b/config/install/core.date_format.fallback.yml
@@ -1,9 +1,6 @@
-uuid: 1c10dc8a-8bad-4d4a-a76a-10565f4dc9c3
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: 6rFstI3nenqtd7t0sGEDbP-1_bTwkXuxvo02QtRvqhU
 id: fallback
 label: 'Fallback date format'
 locked: true

--- a/config/install/core.date_format.html_date.yml
+++ b/config/install/core.date_format.html_date.yml
@@ -1,9 +1,6 @@
-uuid: 7888c401-825b-4391-bdf8-9d0ceb0cd4d2
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: Mz3sF-AmPRxMklEVkan8q_hmfwLpeK9taX3_FWdkK8M
 id: html_date
 label: 'HTML Date'
 locked: true

--- a/config/install/core.date_format.html_datetime.yml
+++ b/config/install/core.date_format.html_datetime.yml
@@ -1,9 +1,6 @@
-uuid: b4149429-1568-4125-9b08-ebbb0c2d81c1
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: 3ws5o4vv_ydCCtqYg506K8KO0wh3ASKiDQ4WaAo5IFY
 id: html_datetime
 label: 'HTML Datetime'
 locked: true

--- a/config/install/core.date_format.html_month.yml
+++ b/config/install/core.date_format.html_month.yml
@@ -1,9 +1,6 @@
-uuid: 899ddb0a-d924-4f61-8c18-c2b212e83db9
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: lG3JEx6IOReOCwqk-xC5kwSah56Vz0mfquBRUHpEbXQ
 id: html_month
 label: 'HTML Month'
 locked: true

--- a/config/install/core.date_format.html_time.yml
+++ b/config/install/core.date_format.html_time.yml
@@ -1,9 +1,6 @@
-uuid: 7efbf6b8-3d77-43e0-aeaf-271ab51e9ab0
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: hk9PtulhJ6glQT9Zdz48n9zhHwwUsxaPje3YVCbL2R4
 id: html_time
 label: 'HTML Time'
 locked: true

--- a/config/install/core.date_format.html_week.yml
+++ b/config/install/core.date_format.html_week.yml
@@ -1,9 +1,6 @@
-uuid: 21244ad1-40b0-4d66-b636-1acf03ce7fed
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: pzVtsJc3JCu57yW6IE1YWjqFAGY7tohGBvPcCrxQV6Y
 id: html_week
 label: 'HTML Week'
 locked: true

--- a/config/install/core.date_format.html_year.yml
+++ b/config/install/core.date_format.html_year.yml
@@ -1,9 +1,6 @@
-uuid: 046d3bcd-e904-4df7-b709-9025d12391cf
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: lmKQPT0x7UipUrbdnoURt8GjSVmBg5pdtR9d4ZIMqEs
 id: html_year
 label: 'HTML Year'
 locked: true

--- a/config/install/core.date_format.html_yearless_date.yml
+++ b/config/install/core.date_format.html_yearless_date.yml
@@ -1,9 +1,6 @@
-uuid: 9f6e02e7-e8cd-484a-a276-4c997e7325bb
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: cwanHy4JPCtdcK_nzF31k2ZKaqUWlH1g_j9wAk8E54s
 id: html_yearless_date
 label: 'HTML Yearless date'
 locked: true

--- a/config/install/core.date_format.long.yml
+++ b/config/install/core.date_format.long.yml
@@ -1,9 +1,6 @@
-uuid: 21774a00-2a3d-49d8-8ea6-e9b59dd55fb1
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: x8XWKMvWcoMlcAU0HIGtIBFikcppleFcjv6ls_nW_rw
 id: long
 label: 'Default long date'
 locked: false

--- a/config/install/core.date_format.medium.yml
+++ b/config/install/core.date_format.medium.yml
@@ -1,9 +1,6 @@
-uuid: 44509f95-8700-4e64-94dd-7d51525a6dc5
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: fiv86hAOvigvQvuPT3av0I-INkoqqteNkh8NojXcsIk
 id: medium
 label: 'Default medium date'
 locked: false

--- a/config/install/core.date_format.short.yml
+++ b/config/install/core.date_format.short.yml
@@ -1,9 +1,6 @@
-uuid: 3b5a26d8-be61-4a5d-8faf-bc80d3702481
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: TzR2wsj7QApTd7nXRjfB_9XY2rDv7S3-8hEXm4YTtFc
 id: short
 label: 'Default short date'
 locked: false

--- a/config/install/core.entity_form_display.media.file.default.yml
+++ b/config/install/core.entity_form_display.media.file.default.yml
@@ -1,4 +1,3 @@
-uuid: 5ef7837a-6a18-4406-9629-3153d4e1f985
 langcode: en
 status: true
 dependencies:
@@ -11,8 +10,6 @@ dependencies:
   module:
     - file
     - path
-_core:
-  default_config_hash: HElgI4ObrcdQzGQIJssXKCxoRW1tm-Plz7ulhAQ-zSQ
 id: media.file.default
 targetEntityType: media
 bundle: file

--- a/config/install/core.entity_form_display.media.file.media_library.yml
+++ b/config/install/core.entity_form_display.media.file.media_library.yml
@@ -1,4 +1,3 @@
-uuid: fe6b5340-4f5e-408a-95c4-12417974b4f4
 langcode: en
 status: true
 dependencies:
@@ -9,8 +8,6 @@ dependencies:
     - field.field.media.file.field_mime_type
     - field.field.media.file.field_upload_name
     - media.type.file
-_core:
-  default_config_hash: RaLEMFNOOVL0KzQT20PXogZTrFmkcDo-8CUQcRnOYis
 id: media.file.media_library
 targetEntityType: media
 bundle: file

--- a/config/install/core.entity_form_display.media.image.default.yml
+++ b/config/install/core.entity_form_display.media.image.default.yml
@@ -1,4 +1,3 @@
-uuid: 51795692-02de-4374-ae2b-5d59816b3b78
 langcode: en
 status: true
 dependencies:
@@ -14,8 +13,6 @@ dependencies:
   module:
     - image
     - path
-_core:
-  default_config_hash: eRQLAD2o1DDVDUE-EStTcEZTd2mekJzF7t1bLbGp4t4
 id: media.image.default
 targetEntityType: media
 bundle: image

--- a/config/install/core.entity_form_display.media.image.media_library.yml
+++ b/config/install/core.entity_form_display.media.image.media_library.yml
@@ -1,4 +1,3 @@
-uuid: a69eb95b-2242-43c4-8b17-85552629a2f0
 langcode: en
 status: true
 dependencies:
@@ -14,8 +13,6 @@ dependencies:
     - media.type.image
   module:
     - image
-_core:
-  default_config_hash: 6jZxtylAz3-6imvQosadcx97lDnc0GkRyfJuz_m5xvc
 id: media.image.media_library
 targetEntityType: media
 bundle: image

--- a/config/install/core.entity_form_display.media.remote_video.default.yml
+++ b/config/install/core.entity_form_display.media.remote_video.default.yml
@@ -1,4 +1,3 @@
-uuid: f9243fa9-3b6f-457f-a641-a03b788f7d7a
 langcode: en
 status: true
 dependencies:
@@ -12,8 +11,6 @@ dependencies:
   module:
     - media
     - path
-_core:
-  default_config_hash: CV7kX6BhXz8ywywilR3fKMIN3jWzwEFXIJg5_t6TmFs
 id: media.remote_video.default
 targetEntityType: media
 bundle: remote_video

--- a/config/install/core.entity_form_display.media.remote_video.media_library.yml
+++ b/config/install/core.entity_form_display.media.remote_video.media_library.yml
@@ -1,4 +1,3 @@
-uuid: 2cb300d1-7414-4985-b2dc-e3bdc978227d
 langcode: en
 status: true
 dependencies:
@@ -10,8 +9,6 @@ dependencies:
     - field.field.media.remote_video.field_provider
     - field.field.media.remote_video.field_width
     - media.type.remote_video
-_core:
-  default_config_hash: 5En9M_DFpY0hyI5ceR6M9pU63Ztcs33RfySNFbkjAj0
 id: media.remote_video.media_library
 targetEntityType: media
 bundle: remote_video

--- a/config/install/core.entity_form_display.node.basic_page.default.yml
+++ b/config/install/core.entity_form_display.node.basic_page.default.yml
@@ -1,4 +1,3 @@
-uuid: 90a82e9f-5d2b-44e1-8e72-e486fbaf15ec
 langcode: en
 status: true
 dependencies:
@@ -8,8 +7,6 @@ dependencies:
   module:
     - path
     - text
-_core:
-  default_config_hash: 5yKemuQiaLDHbYMQdqvHyKy6ryk4wDLy0FpFtcgpB8k
 id: node.basic_page.default
 targetEntityType: node
 bundle: basic_page

--- a/config/install/core.entity_form_display.node.page.default.yml
+++ b/config/install/core.entity_form_display.node.page.default.yml
@@ -1,4 +1,3 @@
-uuid: ac588589-5ac0-41b3-8554-0e8a4467b006
 langcode: en
 status: true
 dependencies:
@@ -10,8 +9,6 @@ dependencies:
     - media_library
     - path
     - text
-_core:
-  default_config_hash: 7xGzwAgaj26zsg0PwsTqs9qZ7xS8cFj3K6fMlDJ8dMs
 id: node.page.default
 targetEntityType: node
 bundle: page

--- a/config/install/core.entity_form_display.user.user.default.yml
+++ b/config/install/core.entity_form_display.user.user.default.yml
@@ -1,12 +1,9 @@
-uuid: 0830c92d-3b6c-4c45-87df-0c7a2cd0174d
 langcode: en
 status: true
 dependencies:
   module:
     - path
     - user
-_core:
-  default_config_hash: RIxbE6uKdRL_T8W2Yt0nBRNZ3GiqDu52AyAd-7q1u-Q
 id: user.user.default
 targetEntityType: user
 bundle: user

--- a/config/install/core.entity_form_mode.media.media_library.yml
+++ b/config/install/core.entity_form_mode.media.media_library.yml
@@ -1,4 +1,3 @@
-uuid: fdedd593-5f40-49cc-b5da-10b216d89998
 langcode: en
 status: true
 dependencies:
@@ -7,8 +6,6 @@ dependencies:
       - media_library
   module:
     - media
-_core:
-  default_config_hash: zWbLkbQpIXegwOCqsCMIoxZFfNZrdJjGnLwvr-tGsr0
 id: media.media_library
 label: 'Media library'
 targetEntityType: media

--- a/config/install/core.entity_form_mode.user.register.yml
+++ b/config/install/core.entity_form_mode.user.register.yml
@@ -1,11 +1,8 @@
-uuid: 5c5ecba7-85b8-4971-91c5-2338ef6628a2
 langcode: en
 status: true
 dependencies:
   module:
     - user
-_core:
-  default_config_hash: RkWs2KwlgFp1TfSTIDJpRjdsbeAPEfg1KgTWHhSxBjQ
 id: user.register
 label: Register
 targetEntityType: user

--- a/config/install/core.entity_view_display.media.file.default.yml
+++ b/config/install/core.entity_view_display.media.file.default.yml
@@ -1,4 +1,3 @@
-uuid: 9f42d3a6-40a3-45f0-b3a7-212742383137
 langcode: en
 status: true
 dependencies:
@@ -13,8 +12,6 @@ dependencies:
     - file
     - image
     - user
-_core:
-  default_config_hash: 6m35YXDH-29gD_WthnrDc7ZKO8ydYCygB3EY2TSLeB4
 id: media.file.default
 targetEntityType: media
 bundle: file

--- a/config/install/core.entity_view_display.media.file.media_library.yml
+++ b/config/install/core.entity_view_display.media.file.media_library.yml
@@ -1,4 +1,3 @@
-uuid: 6c002841-f214-4eca-a85d-68990ebb7530
 langcode: en
 status: true
 dependencies:
@@ -12,8 +11,6 @@ dependencies:
     - media.type.file
   module:
     - image
-_core:
-  default_config_hash: cVBdRrDSQZ2rPdAmlbLQU3NE-nRdoYulSmlEMdHyYk4
 id: media.file.media_library
 targetEntityType: media
 bundle: file

--- a/config/install/core.entity_view_display.media.image.default.yml
+++ b/config/install/core.entity_view_display.media.image.default.yml
@@ -1,4 +1,3 @@
-uuid: e522e9f5-72ba-420d-8688-fd5968deb738
 langcode: en
 status: true
 dependencies:
@@ -14,8 +13,6 @@ dependencies:
   module:
     - image
     - user
-_core:
-  default_config_hash: fah_LD4gNfhQha7cu630PxqXykKCBl2IrrETrjyyKpQ
 id: media.image.default
 targetEntityType: media
 bundle: image

--- a/config/install/core.entity_view_display.media.image.media_library.yml
+++ b/config/install/core.entity_view_display.media.image.media_library.yml
@@ -1,4 +1,3 @@
-uuid: 27ded318-860f-40ce-9944-21bc25199ec7
 langcode: en
 status: true
 dependencies:
@@ -14,8 +13,6 @@ dependencies:
     - media.type.image
   module:
     - image
-_core:
-  default_config_hash: yualLnGbbPHN6v4YET20WIfzGPGxOh_ZNqeuZVXAj4s
 id: media.image.media_library
 targetEntityType: media
 bundle: image

--- a/config/install/core.entity_view_display.media.remote_video.default.yml
+++ b/config/install/core.entity_view_display.media.remote_video.default.yml
@@ -1,4 +1,3 @@
-uuid: 6f409a86-ac92-43fa-9db2-7f561ea3f7fa
 langcode: en
 status: true
 dependencies:
@@ -14,8 +13,6 @@ dependencies:
     - image
     - media
     - user
-_core:
-  default_config_hash: Sg8I0LHrz_mkOABMRg9aBbnH7Rkn1Y3a965hP299lnw
 id: media.remote_video.default
 targetEntityType: media
 bundle: remote_video

--- a/config/install/core.entity_view_display.media.remote_video.media_library.yml
+++ b/config/install/core.entity_view_display.media.remote_video.media_library.yml
@@ -1,4 +1,3 @@
-uuid: 9d42b5b4-6806-4cde-a37e-4f2c85a0abde
 langcode: en
 status: true
 dependencies:
@@ -13,8 +12,6 @@ dependencies:
     - media.type.remote_video
   module:
     - image
-_core:
-  default_config_hash: '-D16I8MK6nNrsnsCRTYoROoANnOMXubWc_Nmr6dA2pU'
 id: media.remote_video.media_library
 targetEntityType: media
 bundle: remote_video

--- a/config/install/core.entity_view_display.node.basic_page.default.yml
+++ b/config/install/core.entity_view_display.node.basic_page.default.yml
@@ -1,4 +1,3 @@
-uuid: bfa33d03-8127-4d83-befe-31901c15603c
 langcode: en
 status: true
 dependencies:
@@ -8,8 +7,6 @@ dependencies:
   module:
     - text
     - user
-_core:
-  default_config_hash: 1Fs8KO7YjtsES6Py1GH6yi7TxdjgYluK9C4c-IxJmP4
 id: node.basic_page.default
 targetEntityType: node
 bundle: basic_page

--- a/config/install/core.entity_view_display.node.basic_page.teaser.yml
+++ b/config/install/core.entity_view_display.node.basic_page.teaser.yml
@@ -1,4 +1,3 @@
-uuid: cdd72b89-fb49-46c0-a166-4f030d5b6a45
 langcode: en
 status: true
 dependencies:
@@ -9,8 +8,6 @@ dependencies:
   module:
     - text
     - user
-_core:
-  default_config_hash: 81Vi00qaTtZHGuq6QLAdn1uiurM8X3ts6xgi60nnHrE
 id: node.basic_page.teaser
 targetEntityType: node
 bundle: basic_page

--- a/config/install/core.entity_view_display.node.page.default.yml
+++ b/config/install/core.entity_view_display.node.page.default.yml
@@ -1,4 +1,3 @@
-uuid: a3c93bf6-08aa-4b83-98c2-b6a7efc85b0c
 langcode: en
 status: true
 dependencies:
@@ -9,8 +8,6 @@ dependencies:
   module:
     - text
     - user
-_core:
-  default_config_hash: OL3WFD5EdTARO5YKv86NeB94mRK7kuCJPvKSaY3qP10
 id: node.page.default
 targetEntityType: node
 bundle: page

--- a/config/install/core.entity_view_display.node.page.teaser.yml
+++ b/config/install/core.entity_view_display.node.page.teaser.yml
@@ -1,4 +1,3 @@
-uuid: 30f3893f-6912-4f0f-acaf-c97afef219c6
 langcode: en
 status: true
 dependencies:
@@ -10,8 +9,6 @@ dependencies:
   module:
     - text
     - user
-_core:
-  default_config_hash: hC7pcAQnrpBZymIMMImE6sAYkHllvoxJteaHU9Z4nOY
 id: node.page.teaser
 targetEntityType: node
 bundle: page

--- a/config/install/core.entity_view_mode.block.token.yml
+++ b/config/install/core.entity_view_mode.block.token.yml
@@ -1,11 +1,8 @@
-uuid: b369c5b6-103e-4560-a702-77f694fa4540
 langcode: en
 status: true
 dependencies:
   module:
     - block
-_core:
-  default_config_hash: wF6jHgjsEUfJXz51Oq3ecKxpGpfZBz87UeOw2kxskTY
 id: block.token
 label: Token
 targetEntityType: block

--- a/config/install/core.entity_view_mode.block_content.full.yml
+++ b/config/install/core.entity_view_mode.block_content.full.yml
@@ -1,11 +1,8 @@
-uuid: 1ea33ba1-6ef3-4bed-8c6d-26b98e0601e0
 langcode: en
 status: false
 dependencies:
   module:
     - block_content
-_core:
-  default_config_hash: pdLxOh9etdbdGDsoK5m-nTDtOQcu66toQRufD0EM0yE
 id: block_content.full
 label: Full
 targetEntityType: block_content

--- a/config/install/core.entity_view_mode.block_content.token.yml
+++ b/config/install/core.entity_view_mode.block_content.token.yml
@@ -1,11 +1,8 @@
-uuid: 4c141a26-b2c1-4af5-8ffa-23c2f3c9d10b
 langcode: en
 status: true
 dependencies:
   module:
     - block_content
-_core:
-  default_config_hash: 8a0R0nU5Si-dzyxnuSHsHzYbgB1yHXRlspfOb7VqLsY
 id: block_content.token
 label: Token
 targetEntityType: block_content

--- a/config/install/core.entity_view_mode.file.token.yml
+++ b/config/install/core.entity_view_mode.file.token.yml
@@ -1,11 +1,8 @@
-uuid: 1c46def9-d64a-462d-88c7-b7e5454241f3
 langcode: en
 status: true
 dependencies:
   module:
     - file
-_core:
-  default_config_hash: Jf7ux1TgSVXnzAXyVY4JRGktR2NUtCpnPON76425iW0
 id: file.token
 label: Token
 targetEntityType: file

--- a/config/install/core.entity_view_mode.media.full.yml
+++ b/config/install/core.entity_view_mode.media.full.yml
@@ -1,11 +1,8 @@
-uuid: a0e85fd5-eb79-4183-8839-782ccc441aac
 langcode: en
 status: false
 dependencies:
   module:
     - media
-_core:
-  default_config_hash: qswsgRCSrnwyr-txnYTNRWVdWgJEXOf7ihLYCTlHZ_w
 id: media.full
 label: 'Full content'
 targetEntityType: media

--- a/config/install/core.entity_view_mode.media.media_library.yml
+++ b/config/install/core.entity_view_mode.media.media_library.yml
@@ -1,4 +1,3 @@
-uuid: a8dfc0ba-016f-4d86-a710-38248a5568b7
 langcode: en
 status: true
 dependencies:
@@ -7,8 +6,6 @@ dependencies:
       - media_library
   module:
     - media
-_core:
-  default_config_hash: '-0U4eT1WicbZPNbpUoYBmG7L0W8Ix65nOtQp-kHYOIM'
 id: media.media_library
 label: 'Media library'
 targetEntityType: media

--- a/config/install/core.entity_view_mode.media.token.yml
+++ b/config/install/core.entity_view_mode.media.token.yml
@@ -1,11 +1,8 @@
-uuid: 20578fc4-d71e-4994-ae82-a643f1fcf431
 langcode: en
 status: true
 dependencies:
   module:
     - media
-_core:
-  default_config_hash: W-9Q60_zlkOYvPSYuB7LnZiBqTpOQksmEhgYkXwnW04
 id: media.token
 label: Token
 targetEntityType: media

--- a/config/install/core.entity_view_mode.node.full.yml
+++ b/config/install/core.entity_view_mode.node.full.yml
@@ -1,11 +1,8 @@
-uuid: b436e45d-7ef7-4a9d-98b2-6da13191352b
 langcode: en
 status: false
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: 53xaXWblQludZQhwLuYiLfZ84rqbkUn_ihijlQfJlW8
 id: node.full
 label: 'Full content'
 targetEntityType: node

--- a/config/install/core.entity_view_mode.node.rss.yml
+++ b/config/install/core.entity_view_mode.node.rss.yml
@@ -1,11 +1,8 @@
-uuid: 958b876a-aa7e-4602-8d6e-7216eb464e23
 langcode: en
 status: false
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: BlYR1GMohE3vvW8Nql5WDFdx6ij8Y7NWRS4o5u4IfVg
 id: node.rss
 label: RSS
 targetEntityType: node

--- a/config/install/core.entity_view_mode.node.search_index.yml
+++ b/config/install/core.entity_view_mode.node.search_index.yml
@@ -1,11 +1,8 @@
-uuid: 16f2669f-9cbf-4e8f-b2f3-5ee53d86a61f
 langcode: en
 status: false
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: fa6tVwqKKN1jh9ryH3PeoK8KTj6Na9V1C_yuAYbmo9E
 id: node.search_index
 label: 'Search index'
 targetEntityType: node

--- a/config/install/core.entity_view_mode.node.search_result.yml
+++ b/config/install/core.entity_view_mode.node.search_result.yml
@@ -1,11 +1,8 @@
-uuid: 918bc838-9824-4952-a781-ccbf7ad7b5a9
 langcode: en
 status: false
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: UW5LOx5UlujDJ1Uf0oTM9uZ-S8y6F9vAKtm_6C0WMgo
 id: node.search_result
 label: 'Search result highlighting input'
 targetEntityType: node

--- a/config/install/core.entity_view_mode.node.teaser.yml
+++ b/config/install/core.entity_view_mode.node.teaser.yml
@@ -1,11 +1,8 @@
-uuid: df45ab96-87b6-4bc7-a535-a52c28959d3c
 langcode: en
 status: true
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: uMePBOW0lZzj2rwOaL6gI7k8eJdOBtmEKZNAdTyBbYM
 id: node.teaser
 label: Teaser
 targetEntityType: node

--- a/config/install/core.entity_view_mode.node.token.yml
+++ b/config/install/core.entity_view_mode.node.token.yml
@@ -1,11 +1,8 @@
-uuid: 71edcdd8-4430-4c6a-b52e-df34ff33ab37
 langcode: en
 status: true
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: 0izsg_GSltmyPRXIk3yxuwEgFBRGylgIs9bmCUWFnxw
 id: node.token
 label: Token
 targetEntityType: node

--- a/config/install/core.entity_view_mode.path_alias.token.yml
+++ b/config/install/core.entity_view_mode.path_alias.token.yml
@@ -1,11 +1,8 @@
-uuid: ee594f82-ab35-4b4c-b701-06e6c2b4a35a
 langcode: en
 status: true
 dependencies:
   module:
     - path_alias
-_core:
-  default_config_hash: 2GMZwqYkZeTOx_VcuO7FCiX9L2MGZWvA0ivF8hYlpA0
 id: path_alias.token
 label: Token
 targetEntityType: path_alias

--- a/config/install/core.entity_view_mode.taxonomy_term.full.yml
+++ b/config/install/core.entity_view_mode.taxonomy_term.full.yml
@@ -1,11 +1,8 @@
-uuid: 1b1fb22f-4b39-4f3a-b468-55a71c15f371
 langcode: en
 status: true
 dependencies:
   module:
     - taxonomy
-_core:
-  default_config_hash: rcJxMmMVsBT6cKoQ0n4vaMmHwToqF813HtCc97kJpuI
 id: taxonomy_term.full
 label: 'Taxonomy term page'
 targetEntityType: taxonomy_term

--- a/config/install/core.entity_view_mode.taxonomy_term.token.yml
+++ b/config/install/core.entity_view_mode.taxonomy_term.token.yml
@@ -1,11 +1,8 @@
-uuid: 8a067c07-b7f6-470f-bb45-d067471f9450
 langcode: en
 status: true
 dependencies:
   module:
     - taxonomy
-_core:
-  default_config_hash: tLEdFrNvMVSEeGbjWGeLM7W4vdhsjAuHF_OKgwWVygo
 id: taxonomy_term.token
 label: Token
 targetEntityType: taxonomy_term

--- a/config/install/core.entity_view_mode.user.compact.yml
+++ b/config/install/core.entity_view_mode.user.compact.yml
@@ -1,11 +1,8 @@
-uuid: eff15fee-b17b-4a4d-9baa-a36f7cf6eb2b
 langcode: en
 status: true
 dependencies:
   module:
     - user
-_core:
-  default_config_hash: RzI-nmJ1hzvNkH5X0a46lt9_mhVE-OXW1sLArHe6_dI
 id: user.compact
 label: Compact
 targetEntityType: user

--- a/config/install/core.entity_view_mode.user.full.yml
+++ b/config/install/core.entity_view_mode.user.full.yml
@@ -1,11 +1,8 @@
-uuid: 5468a391-4cc2-4289-a507-3d4968dbe27e
 langcode: en
 status: false
 dependencies:
   module:
     - user
-_core:
-  default_config_hash: GVRdPHv1D2PCujx0UFD_0K_KvyXUBBqDMJZ_5kuDCTg
 id: user.full
 label: 'User account'
 targetEntityType: user

--- a/config/install/core.entity_view_mode.user.token.yml
+++ b/config/install/core.entity_view_mode.user.token.yml
@@ -1,11 +1,8 @@
-uuid: 9f4d9dc3-a858-4078-8392-d0130989d102
 langcode: en
 status: true
 dependencies:
   module:
     - user
-_core:
-  default_config_hash: NVACK077F5ynCGPOzuaNujif2EK8_SdKf_IyEJO0lYg
 id: user.token
 label: Token
 targetEntityType: user

--- a/config/install/core.menu.static_menu_link_overrides.yml
+++ b/config/install/core.menu.static_menu_link_overrides.yml
@@ -1,3 +1,1 @@
 definitions: {  }
-_core:
-  default_config_hash: GTUd2sO_2of6TF_sAqsVajdFLrDNBg6pqbjDJ6ZC-rM

--- a/config/install/dblog.settings.yml
+++ b/config/install/dblog.settings.yml
@@ -1,3 +1,1 @@
 row_limit: 1000
-_core:
-  default_config_hash: EuC7z2PYYFP-KyCrnRLIXEbbh0JK0McjHFDobzgDFvI

--- a/config/install/editor.editor.basic_html.yml
+++ b/config/install/editor.editor.basic_html.yml
@@ -1,4 +1,3 @@
-uuid: 5a5f2945-f91b-4e38-ae44-090194161b1e
 langcode: en
 status: true
 dependencies:
@@ -6,8 +5,6 @@ dependencies:
     - filter.format.basic_html
   module:
     - ckeditor
-_core:
-  default_config_hash: ymKI5ayZSBkIzH6wf6_lbQQjCxPQfXwx9Drh9OyLtww
 format: basic_html
 editor: ckeditor
 settings:

--- a/config/install/field.field.media.file.field_file_size.yml
+++ b/config/install/field.field.media.file.field_file_size.yml
@@ -1,12 +1,9 @@
-uuid: b41aafaf-0913-46b2-8016-fb1ae164500c
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.media.field_file_size
     - media.type.file
-_core:
-  default_config_hash: e0bTfhAbGcJlo1VcwAlA8YgjiKAlxm5bzbjHagSgki8
 id: media.file.field_file_size
 field_name: field_file_size
 entity_type: media

--- a/config/install/field.field.media.file.field_media_file.yml
+++ b/config/install/field.field.media.file.field_media_file.yml
@@ -1,4 +1,3 @@
-uuid: 244de026-1a91-4de0-ace0-37c8ee525ef2
 langcode: en
 status: true
 dependencies:
@@ -7,8 +6,6 @@ dependencies:
     - media.type.file
   module:
     - file
-_core:
-  default_config_hash: l3YTNKroikDUcrT6NOQOHGLHGtSgLPDssp2-O0-nxmQ
 id: media.file.field_media_file
 field_name: field_media_file
 entity_type: media

--- a/config/install/field.field.media.file.field_mime_type.yml
+++ b/config/install/field.field.media.file.field_mime_type.yml
@@ -1,12 +1,9 @@
-uuid: 8dc934b7-01ea-4dda-9407-1dd9e2e0bff0
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.media.field_mime_type
     - media.type.file
-_core:
-  default_config_hash: xt8XOKOiIXcJhATenhs08-CMAn3I4B4Od_ovIaOUh5w
 id: media.file.field_mime_type
 field_name: field_mime_type
 entity_type: media

--- a/config/install/field.field.media.file.field_upload_name.yml
+++ b/config/install/field.field.media.file.field_upload_name.yml
@@ -1,12 +1,9 @@
-uuid: 4c7ebdab-3fd2-45f7-8682-8aeff38a45a6
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.media.field_upload_name
     - media.type.file
-_core:
-  default_config_hash: 7Ro3HeY6VMmqlYMtdCu3bRA6rQunm0_6UU2bJRIlMaU
 id: media.file.field_upload_name
 field_name: field_upload_name
 entity_type: media

--- a/config/install/field.field.media.image.field_file_size.yml
+++ b/config/install/field.field.media.image.field_file_size.yml
@@ -1,12 +1,9 @@
-uuid: 7eff22c9-f2b7-470f-a1f6-ca556e1615d8
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.media.field_file_size
     - media.type.image
-_core:
-  default_config_hash: _9xxveKhFnDBB8PXaFg5zpTVRuX_ret7g73x0J_2Rr8
 id: media.image.field_file_size
 field_name: field_file_size
 entity_type: media

--- a/config/install/field.field.media.image.field_height.yml
+++ b/config/install/field.field.media.image.field_height.yml
@@ -1,12 +1,9 @@
-uuid: b485059d-a3fa-4339-bf02-f4b1f228288d
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.media.field_height
     - media.type.image
-_core:
-  default_config_hash: qfgD61zMZG_PSqONiNXULJMPCA-65NQjm2B4pf4e9rY
 id: media.image.field_height
 field_name: field_height
 entity_type: media

--- a/config/install/field.field.media.image.field_media_image.yml
+++ b/config/install/field.field.media.image.field_media_image.yml
@@ -1,4 +1,3 @@
-uuid: d7b433ed-51be-426f-ae25-38ec8ee4de8e
 langcode: en
 status: true
 dependencies:
@@ -7,8 +6,6 @@ dependencies:
     - media.type.image
   module:
     - image
-_core:
-  default_config_hash: dUx8zHrWQMf-8_d9_pnJTRPO8pVUBH0mE5NNPF7ySIo
 id: media.image.field_media_image
 field_name: field_media_image
 entity_type: media

--- a/config/install/field.field.media.image.field_mime_type.yml
+++ b/config/install/field.field.media.image.field_mime_type.yml
@@ -1,12 +1,9 @@
-uuid: 7b31841a-314c-432d-bc36-30eb555d7efd
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.media.field_mime_type
     - media.type.image
-_core:
-  default_config_hash: UZzi6zwkEjkzPObLViljYzyx4e9StOLlHnM6cCb54yU
 id: media.image.field_mime_type
 field_name: field_mime_type
 entity_type: media

--- a/config/install/field.field.media.image.field_upload_name.yml
+++ b/config/install/field.field.media.image.field_upload_name.yml
@@ -1,12 +1,9 @@
-uuid: e75dff8b-a36f-4b4d-8a23-53c30f09632f
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.media.field_upload_name
     - media.type.image
-_core:
-  default_config_hash: goecLpwJuz28Mrd5iDC7AJcsrtV_XGpNU1Z6X77SHpw
 id: media.image.field_upload_name
 field_name: field_upload_name
 entity_type: media

--- a/config/install/field.field.media.image.field_width.yml
+++ b/config/install/field.field.media.image.field_width.yml
@@ -1,12 +1,9 @@
-uuid: 0ec41df8-021b-479f-be10-64bdc7bc44d5
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.media.field_width
     - media.type.image
-_core:
-  default_config_hash: 0_tCQ587ajwfh3ljcBkmqNcfcRj49AeJI9bxvplOZ5M
 id: media.image.field_width
 field_name: field_width
 entity_type: media

--- a/config/install/field.field.media.remote_video.field_author.yml
+++ b/config/install/field.field.media.remote_video.field_author.yml
@@ -1,12 +1,9 @@
-uuid: 8a386be5-53db-4cca-bd5b-ada3edf66416
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.media.field_author
     - media.type.remote_video
-_core:
-  default_config_hash: 0wGTCl0zQA2CSzkwmrnh4kgTH4fiGSS51bzStdkfa18
 id: media.remote_video.field_author
 field_name: field_author
 entity_type: media

--- a/config/install/field.field.media.remote_video.field_height.yml
+++ b/config/install/field.field.media.remote_video.field_height.yml
@@ -1,12 +1,9 @@
-uuid: e9790a4a-1ca2-4b0a-a43b-5014bb09c490
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.media.field_height
     - media.type.remote_video
-_core:
-  default_config_hash: 8iZ8g4AQf8DjFJDQljCnSPCTQCvHxy0ajQ96LasLom0
 id: media.remote_video.field_height
 field_name: field_height
 entity_type: media

--- a/config/install/field.field.media.remote_video.field_media_oembed_video.yml
+++ b/config/install/field.field.media.remote_video.field_media_oembed_video.yml
@@ -1,12 +1,9 @@
-uuid: a6547e2f-a0df-4ae1-b17f-9654c908b538
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.media.field_media_oembed_video
     - media.type.remote_video
-_core:
-  default_config_hash: nHZJuaT1u5kUysP7MTJUw-9cyfmhh3vPSr4WUsPSUXo
 id: media.remote_video.field_media_oembed_video
 field_name: field_media_oembed_video
 entity_type: media

--- a/config/install/field.field.media.remote_video.field_provider.yml
+++ b/config/install/field.field.media.remote_video.field_provider.yml
@@ -1,12 +1,9 @@
-uuid: 2005ae9c-4817-44cc-955a-5c0b1938cdea
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.media.field_provider
     - media.type.remote_video
-_core:
-  default_config_hash: KOxee-qSgCOeKPzCdmJDQoSIxGwid9Cnm0CROX9xi44
 id: media.remote_video.field_provider
 field_name: field_provider
 entity_type: media

--- a/config/install/field.field.media.remote_video.field_width.yml
+++ b/config/install/field.field.media.remote_video.field_width.yml
@@ -1,12 +1,9 @@
-uuid: ee41b314-740b-41d1-a707-88105598acb8
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.media.field_width
     - media.type.remote_video
-_core:
-  default_config_hash: k1EazPpZs3-TE9lPeePItnUd0qS5MWM0GsO943tJ0Y0
 id: media.remote_video.field_width
 field_name: field_width
 entity_type: media

--- a/config/install/field.field.node.basic_page.body.yml
+++ b/config/install/field.field.node.basic_page.body.yml
@@ -1,4 +1,3 @@
-uuid: b63c455e-6a3d-4f62-9f0a-42f1aae03b9b
 langcode: en
 status: true
 dependencies:
@@ -7,8 +6,6 @@ dependencies:
     - node.type.basic_page
   module:
     - text
-_core:
-  default_config_hash: cn4W1IcaSU1v_wIKLRxKdelQMP3C_0rzhb4AQWKmSx4
 id: node.basic_page.body
 field_name: body
 entity_type: node

--- a/config/install/field.field.node.page.body.yml
+++ b/config/install/field.field.node.page.body.yml
@@ -1,4 +1,3 @@
-uuid: a26483a8-e31b-48d0-970b-9668146247fa
 langcode: en
 status: true
 dependencies:
@@ -7,8 +6,6 @@ dependencies:
     - node.type.page
   module:
     - text
-_core:
-  default_config_hash: cjCql8UL17fN85pHJ2DUJwPqAIAkErD82yHXa8Iodno
 id: node.page.body
 field_name: body
 entity_type: node

--- a/config/install/field.field.node.page.field_image.yml
+++ b/config/install/field.field.node.page.field_image.yml
@@ -1,4 +1,3 @@
-uuid: 6a09e21f-9314-4468-b8e1-587b13ef4848
 langcode: en
 status: true
 dependencies:
@@ -6,8 +5,6 @@ dependencies:
     - field.storage.node.field_image
     - media.type.image
     - node.type.page
-_core:
-  default_config_hash: '-eEC0bzKuaoL1ZLKdNdokT03bsnrsXQ76h68nJxlSeQ'
 id: node.page.field_image
 field_name: field_image
 entity_type: node

--- a/config/install/field.field.user.user.field_last_password_reset.yml
+++ b/config/install/field.field.user.user.field_last_password_reset.yml
@@ -1,4 +1,3 @@
-uuid: fd681962-7bcd-4e01-b053-7fe37ea83fb8
 langcode: en
 status: true
 dependencies:
@@ -10,8 +9,6 @@ dependencies:
   module:
     - datetime
     - user
-_core:
-  default_config_hash: 9KNibQftQSQkxINz3CmNcDC0f6rp2Krw6lkJ2en-G7g
 id: user.user.field_last_password_reset
 field_name: field_last_password_reset
 entity_type: user

--- a/config/install/field.field.user.user.field_password_expiration.yml
+++ b/config/install/field.field.user.user.field_password_expiration.yml
@@ -1,4 +1,3 @@
-uuid: 32064469-4dcf-4fc8-8f27-2114c001fb2a
 langcode: en
 status: true
 dependencies:
@@ -9,8 +8,6 @@ dependencies:
       - password_policy
   module:
     - user
-_core:
-  default_config_hash: VmJSEF3eJIf_XB2mvMElbf3Z85-EXT87lFe_B7YdLKE
 id: user.user.field_password_expiration
 field_name: field_password_expiration
 entity_type: user

--- a/config/install/field.settings.yml
+++ b/config/install/field.settings.yml
@@ -1,3 +1,1 @@
 purge_batch_size: 50
-_core:
-  default_config_hash: WIdvMwg9Pzr7AUJrOf7zi1xsBs_HAA04xzTkTMAkh9I

--- a/config/install/field.storage.block_content.body.yml
+++ b/config/install/field.storage.block_content.body.yml
@@ -1,12 +1,9 @@
-uuid: 62ed6412-bd22-44a3-8d89-d500fe986c99
 langcode: en
 status: true
 dependencies:
   module:
     - block_content
     - text
-_core:
-  default_config_hash: Px2-Kx4NarI0SMAcZuZ8UNzvk2ncRQ0WhIsEWY2Riy8
 id: block_content.body
 field_name: body
 entity_type: block_content

--- a/config/install/field.storage.media.field_author.yml
+++ b/config/install/field.storage.media.field_author.yml
@@ -1,11 +1,8 @@
-uuid: 49c0af3c-b1d9-409d-9166-41d3e626a91a
 langcode: en
 status: true
 dependencies:
   module:
     - media
-_core:
-  default_config_hash: 3YYDrrqjJh30IpRHC86_fgB68nH5e7qmQVPL7zFpwp4
 id: media.field_author
 field_name: field_author
 entity_type: media

--- a/config/install/field.storage.media.field_file_size.yml
+++ b/config/install/field.storage.media.field_file_size.yml
@@ -1,11 +1,8 @@
-uuid: 104e234e-040c-470e-8b1b-8358eaaf7aa3
 langcode: en
 status: true
 dependencies:
   module:
     - media
-_core:
-  default_config_hash: D0QslPM55zzfe2LiMM3kqaKZw4RMRIdkPegUt9hvJxk
 id: media.field_file_size
 field_name: field_file_size
 entity_type: media

--- a/config/install/field.storage.media.field_height.yml
+++ b/config/install/field.storage.media.field_height.yml
@@ -1,11 +1,8 @@
-uuid: 96a2c097-bc10-4d2a-93a6-a6bf3f1b0bd4
 langcode: en
 status: true
 dependencies:
   module:
     - media
-_core:
-  default_config_hash: Bl6Hn6PL_TAs7XKpG7JGxUXpcBMtbp2MAceQQqqsYyM
 id: media.field_height
 field_name: field_height
 entity_type: media

--- a/config/install/field.storage.media.field_media_file.yml
+++ b/config/install/field.storage.media.field_media_file.yml
@@ -1,12 +1,9 @@
-uuid: c63b902e-3ac7-47f9-855a-4f962aef6f10
 langcode: en
 status: true
 dependencies:
   module:
     - file
     - media
-_core:
-  default_config_hash: cHWTVMpIP3YpAfRJklurrHeXWbQLN-RfoUULkPJMdFU
 id: media.field_media_file
 field_name: field_media_file
 entity_type: media

--- a/config/install/field.storage.media.field_media_image.yml
+++ b/config/install/field.storage.media.field_media_image.yml
@@ -1,4 +1,3 @@
-uuid: 2bb8c5fa-0ddb-48c9-8e8c-3416ba5ba461
 langcode: en
 status: true
 dependencies:
@@ -6,8 +5,6 @@ dependencies:
     - file
     - image
     - media
-_core:
-  default_config_hash: m1jAaNgABcR1bVorQZ2JEj_v1NEyUd-b-KiHUHkvdtU
 id: media.field_media_image
 field_name: field_media_image
 entity_type: media

--- a/config/install/field.storage.media.field_media_oembed_video.yml
+++ b/config/install/field.storage.media.field_media_oembed_video.yml
@@ -1,11 +1,8 @@
-uuid: f9df3e2c-15e2-496e-8417-289c0655a91c
 langcode: en
 status: true
 dependencies:
   module:
     - media
-_core:
-  default_config_hash: bhHDmnHFh1iHBqL5W1VjmhDeIzHhdOxEnBmt-t_LhN4
 id: media.field_media_oembed_video
 field_name: field_media_oembed_video
 entity_type: media

--- a/config/install/field.storage.media.field_mime_type.yml
+++ b/config/install/field.storage.media.field_mime_type.yml
@@ -1,11 +1,8 @@
-uuid: b8df2b98-ac31-4477-8974-cf2906b143d0
 langcode: en
 status: true
 dependencies:
   module:
     - media
-_core:
-  default_config_hash: ecCQ1TaVxrfz0egaW7EFFmFJ8jITItLzQ8UhWPVl9uM
 id: media.field_mime_type
 field_name: field_mime_type
 entity_type: media

--- a/config/install/field.storage.media.field_provider.yml
+++ b/config/install/field.storage.media.field_provider.yml
@@ -1,11 +1,8 @@
-uuid: e01d7ebe-a7d8-4e33-acb6-5876c55b7d27
 langcode: en
 status: true
 dependencies:
   module:
     - media
-_core:
-  default_config_hash: DXK6ZOqfqJSfw5ySazN2AQm6Ow9TteBySGO4vOUVIzs
 id: media.field_provider
 field_name: field_provider
 entity_type: media

--- a/config/install/field.storage.media.field_upload_name.yml
+++ b/config/install/field.storage.media.field_upload_name.yml
@@ -1,11 +1,8 @@
-uuid: 71e85ff7-e8ed-47c1-8cf2-16327bbe07b3
 langcode: en
 status: true
 dependencies:
   module:
     - media
-_core:
-  default_config_hash: w3SmBWTdPD6xU2tIhY1Ili14X3Cowuhs7XVElsB7GWI
 id: media.field_upload_name
 field_name: field_upload_name
 entity_type: media

--- a/config/install/field.storage.media.field_width.yml
+++ b/config/install/field.storage.media.field_width.yml
@@ -1,11 +1,8 @@
-uuid: 576efcc9-63b2-453f-a5a3-a553858d6ab3
 langcode: en
 status: true
 dependencies:
   module:
     - media
-_core:
-  default_config_hash: Rul3ChIrzX2aAsG9h9DhXuyQWpv_of2WCWMa0Mgdhho
 id: media.field_width
 field_name: field_width
 entity_type: media

--- a/config/install/field.storage.node.body.yml
+++ b/config/install/field.storage.node.body.yml
@@ -1,12 +1,9 @@
-uuid: dbcf822c-4ad0-4a80-a478-b9afeacdc27c
 langcode: en
 status: true
 dependencies:
   module:
     - node
     - text
-_core:
-  default_config_hash: z0oXY3nriFNYPevtf_Q2v2_i9T43Rda0iwJkIOY5O2E
 id: node.body
 field_name: body
 entity_type: node

--- a/config/install/field.storage.node.field_image.yml
+++ b/config/install/field.storage.node.field_image.yml
@@ -1,12 +1,9 @@
-uuid: 197c8fd9-b240-4c5d-ac33-dffb94ff38d7
 langcode: en
 status: true
 dependencies:
   module:
     - media
     - node
-_core:
-  default_config_hash: qvVChCPQ19vOvPJ0T6wsfSn2HkIiq6qRYD0o79ZpKlY
 id: node.field_image
 field_name: field_image
 entity_type: node

--- a/config/install/field.storage.user.field_last_password_reset.yml
+++ b/config/install/field.storage.user.field_last_password_reset.yml
@@ -1,4 +1,3 @@
-uuid: 51542026-e3ab-4166-8e4f-f15a8867f951
 langcode: en
 status: true
 dependencies:
@@ -8,8 +7,6 @@ dependencies:
   module:
     - datetime
     - user
-_core:
-  default_config_hash: fe_vhJzBU4DNfc97fsLUU54pydpOw-caxcFMckk-UA4
 id: user.field_last_password_reset
 field_name: field_last_password_reset
 entity_type: user

--- a/config/install/field.storage.user.field_password_expiration.yml
+++ b/config/install/field.storage.user.field_password_expiration.yml
@@ -1,4 +1,3 @@
-uuid: b0840765-ba5d-4382-bcd3-b53a763ccb6d
 langcode: en
 status: true
 dependencies:
@@ -7,8 +6,6 @@ dependencies:
       - password_policy
   module:
     - user
-_core:
-  default_config_hash: hZ92ctP_IPOvYwFWeh-8cu0xIcJJXuJ0nV-6IbQT3vM
 id: user.field_password_expiration
 field_name: field_password_expiration
 entity_type: user

--- a/config/install/field_ui.settings.yml
+++ b/config/install/field_ui.settings.yml
@@ -1,3 +1,1 @@
 field_prefix: field_
-_core:
-  default_config_hash: 16qJuhjgZIMVCOqL3VGOZ56BMU2NFVwU83IwBq3_D50

--- a/config/install/file.settings.yml
+++ b/config/install/file.settings.yml
@@ -4,5 +4,3 @@ description:
 icon:
   directory: core/modules/file/icons
 make_unused_managed_files_temporary: false
-_core:
-  default_config_hash: D76-2mFk30BE93q5ofCLbxQLR_fjSij41DAb1WZyAx8

--- a/config/install/filter.format.basic_html.yml
+++ b/config/install/filter.format.basic_html.yml
@@ -1,11 +1,8 @@
-uuid: 0e73f07d-dc2f-47a9-8889-d1418e5db0a9
 langcode: en
 status: true
 dependencies:
   module:
     - media
-_core:
-  default_config_hash: tALIhhx9ZQvDJEP081mZNlkvXuAcJDMa-2J-0btyuRE
 name: 'Basic HTML'
 format: basic_html
 weight: 0

--- a/config/install/filter.format.plain_text.yml
+++ b/config/install/filter.format.plain_text.yml
@@ -1,9 +1,6 @@
-uuid: 2566a698-80fb-46f7-8eb8-558deca4e5d2
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: WMKRgc8bdtrD0YKtJhqJziwCX_butMTtVc09ulcAhsQ
 name: 'Plain text'
 format: plain_text
 weight: 10

--- a/config/install/filter.settings.yml
+++ b/config/install/filter.settings.yml
@@ -1,4 +1,2 @@
 fallback_format: plain_text
 always_show_fallback_choice: false
-_core:
-  default_config_hash: SjnSprJkAPYvT7kHNngLfSxdYJgLW15R9TxiGAqkQxU

--- a/config/install/google_tag.settings.yml
+++ b/config/install/google_tag.settings.yml
@@ -19,5 +19,3 @@ _default_container:
   include_environment: false
   environment_id: ''
   environment_token: ''
-_core:
-  default_config_hash: 1EIsiAMhZd89m-TNQ9Ol4cygO-0U6L0svoKIkbKTv-o

--- a/config/install/image.settings.yml
+++ b/config/install/image.settings.yml
@@ -1,5 +1,3 @@
 preview_image: core/modules/image/sample.png
 allow_insecure_derivatives: false
 suppress_itok_output: false
-_core:
-  default_config_hash: 8dQa2HTGPItlhps4hyorf2hNuxGac0PLH6w6-gDQSQc

--- a/config/install/image.style.large.yml
+++ b/config/install/image.style.large.yml
@@ -1,9 +1,6 @@
-uuid: b5e299e9-2069-4715-acca-125bd738a901
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: 6o6DO3U0A1ie3ruipgAN5Rps-h6_W6A8_NDIYHOpTI8
 name: large
 label: 'Large (480×480)'
 effects:

--- a/config/install/image.style.media_library.yml
+++ b/config/install/image.style.media_library.yml
@@ -1,12 +1,9 @@
-uuid: 29ee6b90-0f58-43a8-8563-46708949c977
 langcode: en
 status: true
 dependencies:
   enforced:
     module:
       - media_library
-_core:
-  default_config_hash: amSMDLFkNvyBWJYuDwyH3fcf2VkafV_2Bvl9GVeZ5Ug
 name: media_library
 label: 'Media Library thumbnail (220x220)'
 effects:

--- a/config/install/image.style.medium.yml
+++ b/config/install/image.style.medium.yml
@@ -1,9 +1,6 @@
-uuid: 8391214b-9269-4664-86c2-1872393603cf
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: 67aNOd17LTeySq63SQ77bSTIF5Z4xP36vlMShS3XNlk
 name: medium
 label: 'Medium (220×220)'
 effects:

--- a/config/install/image.style.thumbnail.yml
+++ b/config/install/image.style.thumbnail.yml
@@ -1,9 +1,6 @@
-uuid: d44830b8-2576-4132-b776-dd1ab286b2e0
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: a_d33hIYCtLDGJVPYNCMgvEDCyRVE5wwOdu-XtwPigk
 name: thumbnail
 label: 'Thumbnail (100×100)'
 effects:

--- a/config/install/libraries.settings.yml
+++ b/config/install/libraries.settings.yml
@@ -6,5 +6,3 @@ definition:
     urls:
       - 'http://cgit.drupalcode.org/libraries_registry/plain/registry/8'
 global_locators: {  }
-_core:
-  default_config_hash: oXyAmVUyrBnUzTJ5CaPOyA8CDbHivPoZ61YOm1dIRls

--- a/config/install/media.settings.yml
+++ b/config/install/media.settings.yml
@@ -2,5 +2,3 @@ icon_base_uri: 'public://media-icons/generic'
 iframe_domain: ''
 oembed_providers_url: 'https://oembed.com/providers.json'
 standalone_url: false
-_core:
-  default_config_hash: gDQMni_lFzJrG9l-iw6safe7bOgRNR2942BAGxASYME

--- a/config/install/media.type.file.yml
+++ b/config/install/media.type.file.yml
@@ -1,9 +1,6 @@
-uuid: 150c975e-dd97-42a8-9eba-a594df834d6b
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: JoTr0N_IXMoxtih_RwKNS4XASsyByepiukqa1o-GR4w
 id: file
 label: File
 description: ''

--- a/config/install/media.type.image.yml
+++ b/config/install/media.type.image.yml
@@ -1,9 +1,6 @@
-uuid: 36a7cd8b-2223-4352-9db3-87a028df1d30
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: 4TU-toYmXNB6w-fYARi1SEG0hKES3t0Rkhi9fCwy3TA
 id: image
 label: Image
 description: ''

--- a/config/install/media.type.remote_video.yml
+++ b/config/install/media.type.remote_video.yml
@@ -1,9 +1,6 @@
-uuid: 86162ec2-5c15-4d52-99c2-7781e86ad775
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: Epbpclz-E9UrcEViUfRsSWnsUjnj66nzMFHFV7rnNlg
 id: remote_video
 label: 'Remote Video'
 description: ''

--- a/config/install/media_library.settings.yml
+++ b/config/install/media_library.settings.yml
@@ -1,3 +1,1 @@
 advanced_ui: true
-_core:
-  default_config_hash: T1N11_CTR5Gd_ZuePJUbjpOB89zmLMclYrz9IChiHfg

--- a/config/install/metatag.metatag_defaults.403.yml
+++ b/config/install/metatag.metatag_defaults.403.yml
@@ -1,9 +1,6 @@
-uuid: 256462af-cb5d-471f-8c15-511cb4fb8beb
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: dDzdYb8AuvhU-snqa03rts7REozNERSyOF_-f5QxQsM
 id: '403'
 label: '403 access denied'
 tags:

--- a/config/install/metatag.metatag_defaults.404.yml
+++ b/config/install/metatag.metatag_defaults.404.yml
@@ -1,9 +1,6 @@
-uuid: c71051d9-9641-4f48-a300-2c629ba4c916
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: mIjpNClPYuH5bdpFSvLFFBnuTcSQgDmbyztt-p7tWs8
 id: '404'
 label: '404 page not found'
 tags:

--- a/config/install/metatag.metatag_defaults.front.yml
+++ b/config/install/metatag.metatag_defaults.front.yml
@@ -1,9 +1,6 @@
-uuid: b08c0223-10ef-4344-9bc9-d72970f13615
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: Ac6ETmgSZH6_bSAu_WqUWM--0z8Bm5gVbJPVdhpkdTE
 id: front
 label: 'Front page'
 tags:

--- a/config/install/metatag.metatag_defaults.global.yml
+++ b/config/install/metatag.metatag_defaults.global.yml
@@ -1,9 +1,6 @@
-uuid: 35a9b6b4-efed-4ee4-8cff-d9e83492b3d5
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: tQGUhRSOvVjWLfbFwPfAcd7MW16Lm2HlsKpWS7ft_Jw
 id: global
 label: Global
 tags:

--- a/config/install/metatag.metatag_defaults.node.yml
+++ b/config/install/metatag.metatag_defaults.node.yml
@@ -1,9 +1,6 @@
-uuid: 8cf170b1-39b4-4434-bc1a-ad758835ded4
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: 3Y9_Tn48e1X2KbgorRR8xsuK1OFAwmgG1cCpka5atyY
 id: node
 label: Content
 tags:

--- a/config/install/metatag.metatag_defaults.taxonomy_term.yml
+++ b/config/install/metatag.metatag_defaults.taxonomy_term.yml
@@ -1,9 +1,6 @@
-uuid: 9904fcf8-0464-4fe7-9fab-5f84c96b1add
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: '-vCZMItr8jDu_VvxwqcTxOTlMQOpexJEabk84Z-Wl8A'
 id: taxonomy_term
 label: 'Taxonomy term'
 tags:

--- a/config/install/metatag.metatag_defaults.user.yml
+++ b/config/install/metatag.metatag_defaults.user.yml
@@ -1,9 +1,6 @@
-uuid: 5fd7d577-75e3-44a7-94e1-1d825bd5edad
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: qAsw2od1yKHjx80PBRiDK61MOtPeL5ukUVA68NZ9WLM
 id: user
 label: User
 tags:

--- a/config/install/node.settings.yml
+++ b/config/install/node.settings.yml
@@ -1,3 +1,1 @@
 use_admin_theme: true
-_core:
-  default_config_hash: Xe0iEnTbZoOw0wybNehJNYbf_OZb6XQyhPKxvrAqGK4

--- a/config/install/node.type.basic_page.yml
+++ b/config/install/node.type.basic_page.yml
@@ -1,9 +1,6 @@
-uuid: d42f998d-d01c-46d8-9fb0-cb95147582d3
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: xGVIG-RI4ZqxVQsvTj9cYngIyNw9WvoP41sb1MxI2X4
 name: 'Basic Page'
 type: basic_page
 description: ''

--- a/config/install/node.type.page.yml
+++ b/config/install/node.type.page.yml
@@ -1,9 +1,6 @@
-uuid: fa28241a-0f23-4ca3-832e-821cab7fea54
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: 9I8An6NHQs1nqE8rWTZFi0d5CXo6CCqJYyYzR-IX5sY
 name: 'Basic Page'
 type: page
 description: ''

--- a/config/install/password_policy.password_policy.standard.yml
+++ b/config/install/password_policy.password_policy.standard.yml
@@ -1,4 +1,3 @@
-uuid: aff5c28a-edd3-4c09-8e99-08afa5a84354
 langcode: en
 status: true
 dependencies: {  }

--- a/config/install/password_policy.settings.yml
+++ b/config/install/password_policy.settings.yml
@@ -1,3 +1,1 @@
 cron_threshold: 250
-_core:
-  default_config_hash: ylS3vsh8Ssk63Wrb_g1Np12zqe2qfK0NX4AOV1OYgLQ

--- a/config/install/pathauto.settings.yml
+++ b/config/install/pathauto.settings.yml
@@ -18,5 +18,3 @@ safe_tokens:
   - login-url
   - url
   - url-brief
-_core:
-  default_config_hash: GWmzH4QXN3qcidA6P2c2LnuUGYsxLcdTec-JM6qFyg4

--- a/config/install/redirect.settings.yml
+++ b/config/install/redirect.settings.yml
@@ -5,5 +5,3 @@ warning: false
 ignore_admin_path: false
 access_check: false
 route_normalizer_enabled: true
-_core:
-  default_config_hash: R8tRbmPDWZRjqw5U048AowikATFv3Er3fEcGogkesLA

--- a/config/install/save_edit.settings.yml
+++ b/config/install/save_edit.settings.yml
@@ -4,5 +4,3 @@ dropbutton: '1'
 hide_default_save: '0'
 unpublish: '0'
 unpublish_new_only: '0'
-_core:
-  default_config_hash: Ru3Ho2DUqjLlDuepa5V_bV4mZAMppaoum9cm2fuXUEY

--- a/config/install/search_api.settings.yml
+++ b/config/install/search_api.settings.yml
@@ -2,5 +2,3 @@ default_cron_limit: 50
 cron_worker_runtime: 15
 default_tracker: default
 tracking_page_size: 100
-_core:
-  default_config_hash: fslMmtRXHRQK7S5DrAt56AexirAiOx-P2jP17V0diMs

--- a/config/install/search_api_db.settings.yml
+++ b/config/install/search_api_db.settings.yml
@@ -1,3 +1,1 @@
 autocomplete_max_occurrences: 0.9
-_core:
-  default_config_hash: O5HGz0bYe1RHRhEL61Uqx5IooHitKDCKIolxzNOJR9U

--- a/config/install/system.action.media_delete_action.yml
+++ b/config/install/system.action.media_delete_action.yml
@@ -1,11 +1,8 @@
-uuid: 502ee77c-8ccc-4cda-bb58-3120b35d3455
 langcode: en
 status: true
 dependencies:
   module:
     - media
-_core:
-  default_config_hash: Uo5V-hqp4j3ITyK-jXeaSiikwM7KPpW_Jg9Wenbultc
 id: media_delete_action
 label: 'Delete media'
 type: media

--- a/config/install/system.action.media_publish_action.yml
+++ b/config/install/system.action.media_publish_action.yml
@@ -1,11 +1,8 @@
-uuid: 4a78225e-c697-46f8-8ae4-0c8f02607164
 langcode: en
 status: true
 dependencies:
   module:
     - media
-_core:
-  default_config_hash: 7ozo1YYGr9ooNWhnWnuHW7IALaeP9DtThAa1d9_v4tM
 id: media_publish_action
 label: 'Publish media'
 type: media

--- a/config/install/system.action.media_save_action.yml
+++ b/config/install/system.action.media_save_action.yml
@@ -1,11 +1,8 @@
-uuid: bf2a27db-bd47-4f00-8e47-98510cd1065f
 langcode: en
 status: true
 dependencies:
   module:
     - media
-_core:
-  default_config_hash: AzxtgzIBTcbgXBl8LI7n6BpBdIn3Jx8-MaBBRN8fAPc
 id: media_save_action
 label: 'Save media'
 type: media

--- a/config/install/system.action.media_unpublish_action.yml
+++ b/config/install/system.action.media_unpublish_action.yml
@@ -1,11 +1,8 @@
-uuid: 0d67524c-f636-4439-94aa-9426b7f22815
 langcode: en
 status: true
 dependencies:
   module:
     - media
-_core:
-  default_config_hash: o8QVeg0hPK_WXTo-zBPSaZQrTK7v0DO3JpJVVCBWL_o
 id: media_unpublish_action
 label: 'Unpublish media'
 type: media

--- a/config/install/system.action.node_delete_action.yml
+++ b/config/install/system.action.node_delete_action.yml
@@ -1,11 +1,8 @@
-uuid: 76e40ca7-a4f2-4abc-a9f5-f2c4a9fabfe8
 langcode: en
 status: true
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: NWMd7pks7CNVphxRSK5GeuK1QjcBDJfxXb4Bg1B59RE
 id: node_delete_action
 label: 'Delete content'
 type: node

--- a/config/install/system.action.node_make_sticky_action.yml
+++ b/config/install/system.action.node_make_sticky_action.yml
@@ -1,11 +1,8 @@
-uuid: e05a5067-ece7-47ba-b3a2-7e4dc088077c
 langcode: en
 status: true
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: Ze-0EqdU4P4Ax3oHYPkZpEP0IO6sGJLiypvD1e5qsNA
 id: node_make_sticky_action
 label: 'Make content sticky'
 type: node

--- a/config/install/system.action.node_make_unsticky_action.yml
+++ b/config/install/system.action.node_make_unsticky_action.yml
@@ -1,11 +1,8 @@
-uuid: be4cdc53-f5a9-4c67-b4f6-956766d1dc64
 langcode: en
 status: true
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: euGukD6n9p2ueN_0oV15-5eaKZHZ1sVCM7MLNHxZGUQ
 id: node_make_unsticky_action
 label: 'Make content unsticky'
 type: node

--- a/config/install/system.action.node_promote_action.yml
+++ b/config/install/system.action.node_promote_action.yml
@@ -1,11 +1,8 @@
-uuid: a0369734-7938-488d-b84b-257fd5d23060
 langcode: en
 status: true
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: WAokAcJRjnK06Y5yfugNKCM0ayRoEssWBWqawUPs2I8
 id: node_promote_action
 label: 'Promote content to front page'
 type: node

--- a/config/install/system.action.node_publish_action.yml
+++ b/config/install/system.action.node_publish_action.yml
@@ -1,11 +1,8 @@
-uuid: 89a577a1-0230-493d-8c02-4e605a4f8132
 langcode: en
 status: true
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: JTUQKY4HzocRim05t4sgMz-LW8Z9UGpu-xarq5HyfHM
 id: node_publish_action
 label: 'Publish content'
 type: node

--- a/config/install/system.action.node_save_action.yml
+++ b/config/install/system.action.node_save_action.yml
@@ -1,11 +1,8 @@
-uuid: d4c3540b-feec-474b-9de0-a45f6bf8b44c
 langcode: en
 status: true
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: km9gya5C-zK9P9uHG3NdzRYAXzByFm4ZI1_MI-Aw9QE
 id: node_save_action
 label: 'Save content'
 type: node

--- a/config/install/system.action.node_unpromote_action.yml
+++ b/config/install/system.action.node_unpromote_action.yml
@@ -1,11 +1,8 @@
-uuid: 00199f6b-5dd8-4865-beef-b338ce495bce
 langcode: en
 status: true
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: iT2Z-ExI65KtFYmah6Phfc73BSIq-s-tyG0NncEfCVs
 id: node_unpromote_action
 label: 'Remove content from front page'
 type: node

--- a/config/install/system.action.node_unpublish_action.yml
+++ b/config/install/system.action.node_unpublish_action.yml
@@ -1,11 +1,8 @@
-uuid: f8668e44-8d5b-465c-a55b-654413e4df12
 langcode: en
 status: true
 dependencies:
   module:
     - node
-_core:
-  default_config_hash: 703K9nC9ZTCcbC6BcVawHKbbu1fOctvD_t5puS8ahJs
 id: node_unpublish_action
 label: 'Unpublish content'
 type: node

--- a/config/install/system.action.pathauto_update_alias_node.yml
+++ b/config/install/system.action.pathauto_update_alias_node.yml
@@ -1,4 +1,3 @@
-uuid: a4ec0cf2-7e92-404f-b126-77e6e78e760e
 langcode: en
 status: true
 dependencies:
@@ -7,8 +6,6 @@ dependencies:
       - node
   module:
     - pathauto
-_core:
-  default_config_hash: hGDkRQ-9ylN3i_hP5KucdcA97E7Ne4xb_7rmrrTS3O4
 id: pathauto_update_alias_node
 label: 'Update URL alias'
 type: node

--- a/config/install/system.action.pathauto_update_alias_user.yml
+++ b/config/install/system.action.pathauto_update_alias_user.yml
@@ -1,4 +1,3 @@
-uuid: 3c98af87-74ca-4ff4-a916-460eb65ffb12
 langcode: en
 status: true
 dependencies:
@@ -7,8 +6,6 @@ dependencies:
       - user
   module:
     - pathauto
-_core:
-  default_config_hash: O0Tcl8_1p1BUEjU0kr2MVhYEgJ5SEtmsblVjfbZu6Rc
 id: pathauto_update_alias_user
 label: 'Update URL alias'
 type: user

--- a/config/install/system.action.redirect_delete_action.yml
+++ b/config/install/system.action.redirect_delete_action.yml
@@ -1,4 +1,3 @@
-uuid: e8b4ebc3-69c9-4e8e-a9c1-efd9b246f2c1
 langcode: en
 status: true
 dependencies:
@@ -7,8 +6,6 @@ dependencies:
       - redirect
   module:
     - redirect
-_core:
-  default_config_hash: ZH2YE4faVTV6aF7VCwkB5OKF-yWiCO-pUTs8VXdJ-Jk
 id: redirect_delete_action
 label: 'Delete redirect'
 type: redirect

--- a/config/install/system.action.taxonomy_term_publish_action.yml
+++ b/config/install/system.action.taxonomy_term_publish_action.yml
@@ -1,11 +1,8 @@
-uuid: af2c2b5c-8fca-468a-af26-f1514bf3cfd1
 langcode: en
 status: true
 dependencies:
   module:
     - taxonomy
-_core:
-  default_config_hash: 3cnej12lubLfooex7vaOFJgKfnFC90a7DYOuEL639YM
 id: taxonomy_term_publish_action
 label: 'Publish taxonomy term'
 type: taxonomy_term

--- a/config/install/system.action.taxonomy_term_unpublish_action.yml
+++ b/config/install/system.action.taxonomy_term_unpublish_action.yml
@@ -1,11 +1,8 @@
-uuid: eb9d864a-2897-4765-8849-3775b3789d58
 langcode: en
 status: true
 dependencies:
   module:
     - taxonomy
-_core:
-  default_config_hash: aa3NsL8ZCT5Uq3Fhe2xwZZ72FvDSWbOE5vKqd_w74wg
 id: taxonomy_term_unpublish_action
 label: 'Unpublish taxonomy term'
 type: taxonomy_term

--- a/config/install/system.action.user_add_role_action.administrator.yml
+++ b/config/install/system.action.user_add_role_action.administrator.yml
@@ -1,4 +1,3 @@
-uuid: 82d29068-dd9f-453b-8ccb-9c6afd8f561c
 langcode: en
 status: true
 dependencies:
@@ -6,8 +5,6 @@ dependencies:
     - user.role.administrator
   module:
     - user
-_core:
-  default_config_hash: nCG8bYPpmM9UPI6eYhIqluPKa-1rV6JRiprWAwJQ_ss
 id: user_add_role_action.administrator
 label: 'Add the Administrator role to the selected user(s)'
 type: user

--- a/config/install/system.action.user_block_user_action.yml
+++ b/config/install/system.action.user_block_user_action.yml
@@ -1,11 +1,8 @@
-uuid: abe46bc1-ac27-4321-8863-6152fae3a5a6
 langcode: en
 status: true
 dependencies:
   module:
     - user
-_core:
-  default_config_hash: AgmWJKtEZj3dfGSJXN6DnuGEJs2K6bwsOndKGqTPkBM
 id: user_block_user_action
 label: 'Block the selected user(s)'
 type: user

--- a/config/install/system.action.user_cancel_user_action.yml
+++ b/config/install/system.action.user_cancel_user_action.yml
@@ -1,11 +1,8 @@
-uuid: 1125ab96-a05c-4e6b-b4bc-85bf6e95bc6f
 langcode: en
 status: true
 dependencies:
   module:
     - user
-_core:
-  default_config_hash: t7p9RBnK0CKjWZTwHL0sI5ynrX5w_zTgHKeS5DzNjHM
 id: user_cancel_user_action
 label: 'Cancel the selected user account(s)'
 type: user

--- a/config/install/system.action.user_remove_role_action.administrator.yml
+++ b/config/install/system.action.user_remove_role_action.administrator.yml
@@ -1,4 +1,3 @@
-uuid: 520d2838-d7b5-46b5-8b3f-7fa427440106
 langcode: en
 status: true
 dependencies:
@@ -6,8 +5,6 @@ dependencies:
     - user.role.administrator
   module:
     - user
-_core:
-  default_config_hash: 50ZiVKrI3hwvZGRr40dwGUREzUOI7oDS_aNaYJ_vb54
 id: user_remove_role_action.administrator
 label: 'Remove the Administrator role from the selected user(s)'
 type: user

--- a/config/install/system.action.user_unblock_user_action.yml
+++ b/config/install/system.action.user_unblock_user_action.yml
@@ -1,11 +1,8 @@
-uuid: 2a10e6f9-70dc-4dfb-b58a-2983ef70ca8f
 langcode: en
 status: true
 dependencies:
   module:
     - user
-_core:
-  default_config_hash: 4FAS-OaYh0QpjkTa01A8VylDeH3PLsPRNycowKnmxeI
 id: user_unblock_user_action
 label: 'Unblock the selected user(s)'
 type: user

--- a/config/install/system.authorize.yml
+++ b/config/install/system.authorize.yml
@@ -1,3 +1,1 @@
 filetransfer_default: null
-_core:
-  default_config_hash: EZAP02EPniF8qNI2_0XnYLjwaF2lNd8pKhgG18QOpcE

--- a/config/install/system.cron.yml
+++ b/config/install/system.cron.yml
@@ -2,5 +2,3 @@ threshold:
   requirements_warning: 172800
   requirements_error: 1209600
 logging: 1
-_core:
-  default_config_hash: xucOzPJvZKtny1iqWq11JN_NbF1-IVokNAuO03TBbss

--- a/config/install/system.date.yml
+++ b/config/install/system.date.yml
@@ -7,5 +7,3 @@ timezone:
     configurable: true
     warn: false
     default: 0
-_core:
-  default_config_hash: Fhp1HnZhhcsEW-xc8cL23RpAiz64Zeovpca-mydOAHQ

--- a/config/install/system.diff.yml
+++ b/config/install/system.diff.yml
@@ -1,5 +1,3 @@
 context:
   lines_leading: 2
   lines_trailing: 2
-_core:
-  default_config_hash: 7PBrR7lM-z7Uk-Oigv7LUWVUqP48ORpfQRAYGwSQt0g

--- a/config/install/system.file.yml
+++ b/config/install/system.file.yml
@@ -3,5 +3,3 @@ default_scheme: public
 path:
   temporary: /tmp
 temporary_maximum_age: 21600
-_core:
-  default_config_hash: L68guYbd1a3gCJkx8q6QlFlKUeCMiiZgh_X2q4hnYxc

--- a/config/install/system.image.gd.yml
+++ b/config/install/system.image.gd.yml
@@ -1,3 +1,1 @@
 jpeg_quality: 75
-_core:
-  default_config_hash: bLx4yJ1Usl3CiP1VJfC-MgauqbADKTaA7mNudvjTghw

--- a/config/install/system.image.yml
+++ b/config/install/system.image.yml
@@ -1,3 +1,1 @@
 toolkit: gd
-_core:
-  default_config_hash: rYfddo0UtH_r6EugtLZhRw-o8V8e1jc5xvutmSoIMXo

--- a/config/install/system.logging.yml
+++ b/config/install/system.logging.yml
@@ -1,3 +1,1 @@
 error_level: hide
-_core:
-  default_config_hash: d37XK8LX-KzK6H5eOW5Gwva1U9qnjN7Iw743LUpMgvo

--- a/config/install/system.mail.yml
+++ b/config/install/system.mail.yml
@@ -1,4 +1,2 @@
 interface:
   default: php_mail
-_core:
-  default_config_hash: K7LsFOjA5ifxYZ1dlwcRM4Vh6p5B4TtJy6bhsUlKEbQ

--- a/config/install/system.maintenance.yml
+++ b/config/install/system.maintenance.yml
@@ -1,4 +1,2 @@
 message: '@site is currently under maintenance. We should be back shortly. Thank you for your patience.'
 langcode: en
-_core:
-  default_config_hash: 8zZyGvH6HhZvRhO7ep890T8htiAsEW5wq46XjP8rK6g

--- a/config/install/system.menu.account.yml
+++ b/config/install/system.menu.account.yml
@@ -1,9 +1,6 @@
-uuid: 3e40bb64-daf8-4304-a39c-7863e9dff1de
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: 3XZXRyvKzo8HDxJ3ova9y7bQbsrJuSMnVIWU7Yr2DaY
 id: account
 label: 'User account menu'
 description: 'Links related to the active user account'

--- a/config/install/system.menu.admin.yml
+++ b/config/install/system.menu.admin.yml
@@ -1,9 +1,6 @@
-uuid: 3a2d1bf7-c6d6-4453-aaad-f8d966f0b4e2
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: UL8T_W50A_MSwavOEEycSqp5_pVc93Xpjzpqoj4LlSM
 id: admin
 label: Administration
 description: 'Administrative task links'

--- a/config/install/system.menu.footer.yml
+++ b/config/install/system.menu.footer.yml
@@ -1,9 +1,6 @@
-uuid: 7a3e6a8f-c87e-4d44-affa-6358ac2c39da
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: ibVgk1uI75uJOLjKlY-IvMvFTrU4N8bCxgBDFJTQhvg
 id: footer
 label: Footer
 description: 'Site information links'

--- a/config/install/system.menu.main.yml
+++ b/config/install/system.menu.main.yml
@@ -1,9 +1,6 @@
-uuid: e41666e8-bdf9-4128-8bec-07d2231f1651
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: FBrMbSy4l11Ndp_-2zFqOjyii6PlP3kGOYby0fvASOc
 id: main
 label: 'Main navigation'
 description: 'Site section links'

--- a/config/install/system.menu.tools.yml
+++ b/config/install/system.menu.tools.yml
@@ -1,9 +1,6 @@
-uuid: 07e8ddb7-d311-4055-8086-7460f4dae655
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: y3T_SIa1FPhrRnfvM4Zq4IJ5Kwlx1K1XJLQeYqC1Zuw
 id: tools
 label: Tools
 description: 'User tool links, often added by modules'

--- a/config/install/system.performance.yml
+++ b/config/install/system.performance.yml
@@ -13,5 +13,3 @@ js:
   preprocess: true
   gzip: true
 stale_file_threshold: 2592000
-_core:
-  default_config_hash: V-TVIVn8qHe9I2Ow7z36avK77nWBlpWhKjNxYRD1kjo

--- a/config/install/system.rss.yml
+++ b/config/install/system.rss.yml
@@ -4,5 +4,3 @@ items:
   limit: 10
   view_mode: rss
 langcode: en
-_core:
-  default_config_hash: oMWKFRGTQw7GF0xZSjDu136e2Q9AOfF_PAF-4_3l-U4

--- a/config/install/system.site.yml
+++ b/config/install/system.site.yml
@@ -1,4 +1,3 @@
-uuid: dd9b2ccb-608b-43ee-8c6e-b701971b3282
 name: 'Drush Site-Install'
 mail: admin@example.com
 slogan: ''
@@ -10,5 +9,3 @@ admin_compact_mode: false
 weight_select_max: 100
 langcode: en
 default_langcode: en
-_core:
-  default_config_hash: gtMLBDZlKrC5Xg2VMbl3BfiFKWLBdJBW9C7gKg3S1Lo

--- a/config/install/system.theme.global.yml
+++ b/config/install/system.theme.global.yml
@@ -12,5 +12,3 @@ logo:
   path: ''
   url: ''
   use_default: true
-_core:
-  default_config_hash: orjxzWmcVuRNgukT5qCOPQ3NEk4Td-T1yKjiiwZQFpk

--- a/config/install/system.theme.yml
+++ b/config/install/system.theme.yml
@@ -1,4 +1,2 @@
 admin: seven
 default: gesso
-_core:
-  default_config_hash: Thkqy9p0V3KHnr-ufpSlZPx4FssEFKwRlLb6tFrGRxo

--- a/config/install/taxonomy.settings.yml
+++ b/config/install/taxonomy.settings.yml
@@ -1,5 +1,3 @@
 maintain_index_table: true
 override_selector: false
 terms_per_page_admin: 100
-_core:
-  default_config_hash: jdiu9dCfRwxIGvwzsQRU_2RyoQKOaH9kuboKr-t1gqs

--- a/config/install/text.settings.yml
+++ b/config/install/text.settings.yml
@@ -1,3 +1,1 @@
 default_summary_length: 600
-_core:
-  default_config_hash: ywwwMnaJYtP0LQX8aL8qc8wVDyDUp4jJBx4KsOVtPmU

--- a/config/install/update.settings.yml
+++ b/config/install/update.settings.yml
@@ -9,5 +9,3 @@ notification:
   emails:
     - admin@example.com
   threshold: all
-_core:
-  default_config_hash: CLwjpCxv5OC-k4Bam3Y-pbWrnsKsw6ChBKXO1xKso2A

--- a/config/install/user.flood.yml
+++ b/config/install/user.flood.yml
@@ -3,5 +3,3 @@ ip_limit: 50
 ip_window: 3600
 user_limit: 5
 user_window: 21600
-_core:
-  default_config_hash: UM9YY0vOEfBqlnLOn27faeKtMB9AuSQUpIS3NURLJmU

--- a/config/install/user.mail.yml
+++ b/config/install/user.mail.yml
@@ -26,5 +26,3 @@ status_canceled:
   body: "[user:display-name],\n\nYour account on [site:name] has been canceled.\n\n--  [site:name] team"
   subject: 'Account details for [user:display-name] at [site:name] (canceled)'
 langcode: en
-_core:
-  default_config_hash: fvYmGug1ZJLgr59NVvviJjFM7L9IbTBUWioLrdSDeJo

--- a/config/install/user.role.administrator.yml
+++ b/config/install/user.role.administrator.yml
@@ -1,9 +1,6 @@
-uuid: d98952d0-eb4c-408c-8cc0-db9d158d5f08
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: wmp8c6RCB2sPpiUM6OlP3X8OB2FuB6N4-mryseoAJ1w
 id: administrator
 label: Administrator
 weight: 2

--- a/config/install/user.role.anonymous.yml
+++ b/config/install/user.role.anonymous.yml
@@ -1,9 +1,6 @@
-uuid: 20730a8b-2d85-4ea9-89a5-3fbac0661d82
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: z4uLE_FPCrRkHRPfF2DaiikbOQDX_QPaXYNKnWQoUsA
 id: anonymous
 label: 'Anonymous user'
 weight: 0

--- a/config/install/user.role.authenticated.yml
+++ b/config/install/user.role.authenticated.yml
@@ -1,9 +1,6 @@
-uuid: e98203a3-d67b-46fc-a1fc-6867219ed816
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: mJTPwUGBfxdOMqJoKJ-qUHWvOsY5XAV41B9h7P41hZE
 id: authenticated
 label: 'Authenticated user'
 weight: 1

--- a/config/install/user.settings.yml
+++ b/config/install/user.settings.yml
@@ -14,5 +14,3 @@ cancel_method: user_cancel_block
 password_reset_timeout: 86400
 password_strength: true
 langcode: en
-_core:
-  default_config_hash: L-QanG6vTHKcMgpp4_cFrNV-l6qJViO8Zh4mrBqmnps

--- a/config/install/views.settings.yml
+++ b/config/install/views.settings.yml
@@ -46,7 +46,5 @@ field_rewrite_elements:
   ins: INS
   q: Q
   s: S
-_core:
-  default_config_hash: QvW2jqpViGqCuTDlnFRitxy7HUVqzcA6p-573WTKpKY
 display_extenders:
   - metatag_display_extender

--- a/config/install/views.view.archive.yml
+++ b/config/install/views.view.archive.yml
@@ -1,4 +1,3 @@
-uuid: fe90d450-9cc3-47e0-8a55-cefed0becf5e
 langcode: en
 status: false
 dependencies:
@@ -7,8 +6,6 @@ dependencies:
   module:
     - node
     - user
-_core:
-  default_config_hash: 69PuyzRIpYDCJsc_1gmBlNy3iuiSCQPhqULqu9wsDiM
 id: archive
 label: Archive
 module: node

--- a/config/install/views.view.block_content.yml
+++ b/config/install/views.view.block_content.yml
@@ -1,12 +1,9 @@
-uuid: 080cde83-d832-49ee-8d26-91d1ca71a584
 langcode: en
 status: true
 dependencies:
   module:
     - block_content
     - user
-_core:
-  default_config_hash: uD1hixu20JdpIowlew9n5JE8fz35UVInslP7GZ33jzY
 id: block_content
 label: 'Custom block library'
 module: views

--- a/config/install/views.view.content.yml
+++ b/config/install/views.view.content.yml
@@ -1,12 +1,9 @@
-uuid: b1028fa3-58ed-4bd1-9f08-90ff5c99dff8
 langcode: en
 status: true
 dependencies:
   module:
     - node
     - user
-_core:
-  default_config_hash: h3p7L4KEfqodEolrB2rkw10bA7SQHjKsMpTxGR7wAtA
 id: content
 label: Content
 module: node

--- a/config/install/views.view.content_recent.yml
+++ b/config/install/views.view.content_recent.yml
@@ -1,12 +1,9 @@
-uuid: ae7326dd-ac1a-4f4b-a921-6fd14a12d211
 langcode: en
 status: true
 dependencies:
   module:
     - node
     - user
-_core:
-  default_config_hash: hIvx_3Tyv5Bat1oV9iLv57fvo49tsB3mi8XOe73HGDU
 id: content_recent
 label: 'Recent content'
 module: node

--- a/config/install/views.view.files.yml
+++ b/config/install/views.view.files.yml
@@ -1,12 +1,9 @@
-uuid: 97c361b0-413a-41a4-aecf-8d0b18b1a8fc
 langcode: en
 status: true
 dependencies:
   module:
     - file
     - user
-_core:
-  default_config_hash: igJYM3QA23F22fGpd5Vx4k5oUP0yvrB898u69T5Kw-Y
 id: files
 label: Files
 module: file

--- a/config/install/views.view.frontpage.yml
+++ b/config/install/views.view.frontpage.yml
@@ -1,4 +1,3 @@
-uuid: 57f15bde-941f-40be-8178-859b223b7c7e
 langcode: en
 status: true
 dependencies:
@@ -8,8 +7,6 @@ dependencies:
   module:
     - node
     - user
-_core:
-  default_config_hash: J6p2cwTFWDF8nxXOl16rOTUmIQiRTK3LAGcQTSywYsU
 id: frontpage
 label: Frontpage
 module: node

--- a/config/install/views.view.glossary.yml
+++ b/config/install/views.view.glossary.yml
@@ -1,4 +1,3 @@
-uuid: bbaa55a7-e272-4358-918b-59a69b082707
 langcode: en
 status: false
 dependencies:
@@ -7,8 +6,6 @@ dependencies:
   module:
     - node
     - user
-_core:
-  default_config_hash: ZR-1SA9QyEo_-MTyaAq83pzEAMnUdMBeRqaOJeD8ofw
 id: glossary
 label: Glossary
 module: node

--- a/config/install/views.view.media.yml
+++ b/config/install/views.view.media.yml
@@ -1,4 +1,3 @@
-uuid: 6e17f890-661d-4466-bcad-67ae2a5e53fb
 langcode: en
 status: true
 dependencies:
@@ -8,8 +7,6 @@ dependencies:
     - image
     - media
     - user
-_core:
-  default_config_hash: qEgBdabAyieu6Vr3j66NBkZ7tLYWaozcRvT-a9qcOgg
 id: media
 label: Media
 module: views

--- a/config/install/views.view.media_library.yml
+++ b/config/install/views.view.media_library.yml
@@ -1,4 +1,3 @@
-uuid: 3746814c-7faa-4135-a488-c8d39c62b601
 langcode: en
 status: true
 dependencies:
@@ -13,8 +12,6 @@ dependencies:
     - media
     - media_library
     - user
-_core:
-  default_config_hash: RqpVnLA6_3Tq7IpbA9GjrZ9V0AL_j4TaoYuRdrVafXo
 id: media_library
 label: 'Media library'
 module: views

--- a/config/install/views.view.redirect.yml
+++ b/config/install/views.view.redirect.yml
@@ -1,4 +1,3 @@
-uuid: 512800cc-835d-4395-80c6-11b60640a09a
 langcode: en
 status: true
 dependencies:
@@ -6,8 +5,6 @@ dependencies:
     - link
     - redirect
     - user
-_core:
-  default_config_hash: rAFsbWY7AO5yAfbdR3AreWB_Q0bJYPQSAHhSWpnAjvo
 id: redirect
 label: Redirect
 module: views

--- a/config/install/views.view.taxonomy_term.yml
+++ b/config/install/views.view.taxonomy_term.yml
@@ -1,4 +1,3 @@
-uuid: 17439549-16a6-4c84-a0a6-03e3e0c94345
 langcode: en
 status: true
 dependencies:
@@ -8,8 +7,6 @@ dependencies:
     - node
     - taxonomy
     - user
-_core:
-  default_config_hash: 4IbxLUHIX8b-44-k0YrT2AxVXml0soUOdYtYS4Xdvy0
 id: taxonomy_term
 label: 'Taxonomy term'
 module: taxonomy

--- a/config/install/views.view.user_admin_people.yml
+++ b/config/install/views.view.user_admin_people.yml
@@ -1,11 +1,8 @@
-uuid: eb4eef54-c5e5-4851-ae77-da3124d86a0c
 langcode: en
 status: true
 dependencies:
   module:
     - user
-_core:
-  default_config_hash: WCUbkI9SLwPTQHQMK_T2ynourhcojr3RLh5TxsKkGWM
 id: user_admin_people
 label: People
 module: user

--- a/config/install/views.view.watchdog.yml
+++ b/config/install/views.view.watchdog.yml
@@ -1,12 +1,9 @@
-uuid: 8328f58e-a502-4fcd-96a2-d41ea4f6cb81
 langcode: en
 status: true
 dependencies:
   module:
     - dblog
     - user
-_core:
-  default_config_hash: tq5cu4PriVbMKqwX-Ev_zzyabwv3H2qCBx4-Gpy6zgk
 id: watchdog
 label: Watchdog
 module: views

--- a/config/install/views.view.who_s_new.yml
+++ b/config/install/views.view.who_s_new.yml
@@ -1,11 +1,8 @@
-uuid: 656431c2-82c2-47c2-9bef-d2aba02f39ab
 langcode: en
 status: true
 dependencies:
   module:
     - user
-_core:
-  default_config_hash: Zg5yStuXA7FMl52ZIqMeiXRATKgZCPDM_0a_5KMQN6I
 id: who_s_new
 label: 'Who''s new'
 module: user

--- a/config/install/views.view.who_s_online.yml
+++ b/config/install/views.view.who_s_online.yml
@@ -1,11 +1,8 @@
-uuid: 0150bae9-a2f6-4ba1-b3f0-1f64c9483faf
 langcode: en
 status: true
 dependencies:
   module:
     - user
-_core:
-  default_config_hash: mIxFXUOPzMJnM2b9g9G4EXzGgbBQyMqgHXEfDCqBjHQ
 id: who_s_online
 label: 'Who''s online block'
 module: user


### PR DESCRIPTION
Cleans up all the config files in the install profile to no longer have a uuid, _core and default_config_hash.

All files changed, but nothing else touched.