### PR TITLE
[DRUPAL-20] Adding sponsor content type

### DIFF
--- a/config/install/core.base_field_override.node.sponsor.promote.yml
+++ b/config/install/core.base_field_override.node.sponsor.promote.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.sponsor
+id: node.sponsor.promote
+field_name: promote
+entity_type: node
+bundle: sponsor
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/install/core.entity_form_display.node.sponsor.default.yml
+++ b/config/install/core.entity_form_display.node.sponsor.default.yml
@@ -1,0 +1,76 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.sponsor.field_image
+    - field.field.node.sponsor.field_link
+    - node.type.sponsor
+  module:
+    - link
+    - media_library
+    - path
+id: node.sponsor.default
+targetEntityType: node
+bundle: sponsor
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_image:
+    weight: 2
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    type: media_library_widget
+    region: content
+  field_link:
+    weight: 1
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  path:
+    type: path
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 7
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 3
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+  url_redirects:
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  promote: true
+  sticky: true

--- a/config/install/core.entity_view_display.node.sponsor.default.yml
+++ b/config/install/core.entity_view_display.node.sponsor.default.yml
@@ -1,0 +1,43 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.sponsor.field_image
+    - field.field.node.sponsor.field_link
+    - node.type.sponsor
+  module:
+    - link
+    - user
+id: node.sponsor.default
+targetEntityType: node
+bundle: sponsor
+mode: default
+content:
+  field_image:
+    weight: 101
+    label: hidden
+    settings:
+      link: true
+      view_mode: default
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+  field_link:
+    weight: 102
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link_separate
+    region: content
+  links:
+    weight: 100
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  search_api_excerpt: true

--- a/config/install/core.entity_view_display.node.sponsor.teaser.yml
+++ b/config/install/core.entity_view_display.node.sponsor.teaser.yml
@@ -1,0 +1,44 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.sponsor.field_image
+    - field.field.node.sponsor.field_link
+    - node.type.sponsor
+  module:
+    - link
+    - user
+id: node.sponsor.teaser
+targetEntityType: node
+bundle: sponsor
+mode: teaser
+content:
+  field_image:
+    type: entity_reference_entity_view
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      link: true
+      view_mode: default
+    third_party_settings: {  }
+  field_link:
+    type: link_separate
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+  links:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  search_api_excerpt: true

--- a/config/install/field.field.node.sponsor.field_image.yml
+++ b/config/install/field.field.node.sponsor.field_image.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_image
+    - media.type.image
+    - node.type.sponsor
+id: node.sponsor.field_image
+field_name: field_image
+entity_type: node
+bundle: sponsor
+label: Logo
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.node.sponsor.field_link.yml
+++ b/config/install/field.field.node.sponsor.field_link.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_link
+    - node.type.sponsor
+  module:
+    - link
+id: node.sponsor.field_link
+field_name: field_link
+entity_type: node
+bundle: sponsor
+label: URL
+description: 'The URL to the sponsor/partner page or website.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 1
+field_type: link

--- a/config/install/field.storage.node.field_link.yml
+++ b/config/install/field.storage.node.field_link.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_link
+field_name: field_link
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/node.type.sponsor.yml
+++ b/config/install/node.type.sponsor.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies: {  }
+name: Sponsor/Partner
+type: sponsor
+description: 'Sponsor/Partner represent a organization or entity working with, sponsoring, or partnering alongside.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false


### PR DESCRIPTION
Adding sponsor content type, fields, form display and basic display modes.

Followed mostly from the content model spreadsheet, but didn't add description.
https://docs.google.com/spreadsheets/d/1G3mIJ3n0epfAdcpX7yloEHCeuRC1P4YJQ9a0wqE0GS4/edit#gid=0

Screenshots of admin
![image](https://user-images.githubusercontent.com/6014974/124324712-0a7d2000-db49-11eb-949d-49e323542600.png)

![image](https://user-images.githubusercontent.com/6014974/124324732-12d55b00-db49-11eb-9d4c-ee3b7b658831.png)
